### PR TITLE
328: Ensure confirmation dialog is shown for all delete actions

### DIFF
--- a/lib/features/campaigns/screens/door_edit.dart
+++ b/lib/features/campaigns/screens/door_edit.dart
@@ -28,7 +28,7 @@ class DoorEdit extends StatefulWidget {
   State<DoorEdit> createState() => _DoorEditState();
 }
 
-class _DoorEditState extends State<DoorEdit> with AddressMixin, DoorValidator {
+class _DoorEditState extends State<DoorEdit> with AddressMixin, DoorValidator, ConfirmDelete {
   @override
   TextEditingController streetTextController = TextEditingController();
   @override
@@ -115,7 +115,7 @@ class _DoorEditState extends State<DoorEdit> with AddressMixin, DoorValidator {
           Container(
             padding: EdgeInsets.only(top: 6, bottom: 24),
             child: DeleteAndSaveWidget(
-              onDelete: _onDeletePressed,
+              onDelete: () => confirmDelete(context, _onDeletePressed),
               onSave: _saveDoor,
             ),
           ),
@@ -146,5 +146,57 @@ class _DoorEditState extends State<DoorEdit> with AddressMixin, DoorValidator {
     );
     widget.onSave(updateModel);
     _closeDialog();
+  }
+}
+
+mixin ConfirmDelete {
+  void confirmDelete(BuildContext context, void Function() onDeletePressed) async {
+    final theme = Theme.of(context);
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      barrierDismissible: true,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          backgroundColor: ThemeColors.alertBackground,
+          title: Center(
+            child: Text(
+              '${t.campaigns.deleteEntry.label}?',
+              style: theme.textTheme.titleMedium?.apply(color: theme.colorScheme.surface),
+            ),
+          ),
+          content: Text(
+            t.campaigns.deleteEntry.confirmation_dialog,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.labelMedium?.apply(
+              color: theme.colorScheme.surface,
+              fontSizeDelta: 1,
+            ),
+          ),
+          actionsAlignment: MainAxisAlignment.spaceBetween,
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.maybePop(context, false),
+              child: Text(
+                t.common.actions.cancel,
+                style: theme.textTheme.labelLarge?.apply(color: ThemeColors.textCancel),
+              ),
+            ),
+            TextButton(
+              onPressed: () => Navigator.maybePop(context, true),
+              child: Text(
+                t.common.actions.delete,
+                style: theme.textTheme.labelLarge?.apply(
+                  color: ThemeColors.textWarning,
+                  fontWeightDelta: 2,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+    if (shouldDelete ?? false) {
+      onDeletePressed();
+    }
   }
 }

--- a/lib/features/campaigns/screens/flyer_edit.dart
+++ b/lib/features/campaigns/screens/flyer_edit.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/features/campaigns/models/flyer/flyer_detail_model.dart';
 import 'package:gruene_app/features/campaigns/models/flyer/flyer_update_model.dart';
+import 'package:gruene_app/features/campaigns/screens/door_edit.dart';
 import 'package:gruene_app/features/campaigns/screens/doors_add_screen.dart';
 import 'package:gruene_app/features/campaigns/screens/flyer_add_screen.dart';
 import 'package:gruene_app/features/campaigns/screens/map_consumer.dart';
@@ -24,7 +25,7 @@ class FlyerEdit extends StatefulWidget {
   State<FlyerEdit> createState() => _FlyerEditState();
 }
 
-class _FlyerEditState extends State<FlyerEdit> with AddressMixin, FlyerValidator {
+class _FlyerEditState extends State<FlyerEdit> with AddressMixin, FlyerValidator, ConfirmDelete {
   @override
   TextEditingController streetTextController = TextEditingController();
   @override
@@ -99,7 +100,7 @@ class _FlyerEditState extends State<FlyerEdit> with AddressMixin, FlyerValidator
           Container(
             padding: EdgeInsets.only(top: 6, bottom: 24),
             child: DeleteAndSaveWidget(
-              onDelete: _onDeletePressed,
+              onDelete: () => confirmDelete(context, _onDeletePressed),
               onSave: _saveFlyer,
             ),
           ),

--- a/lib/features/campaigns/screens/poster_edit.dart
+++ b/lib/features/campaigns/screens/poster_edit.dart
@@ -6,6 +6,7 @@ import 'package:gruene_app/features/campaigns/helper/media_helper.dart';
 import 'package:gruene_app/features/campaigns/helper/poster_status.dart';
 import 'package:gruene_app/features/campaigns/models/posters/poster_detail_model.dart';
 import 'package:gruene_app/features/campaigns/models/posters/poster_update_model.dart';
+import 'package:gruene_app/features/campaigns/screens/door_edit.dart';
 import 'package:gruene_app/features/campaigns/screens/doors_add_screen.dart';
 import 'package:gruene_app/features/campaigns/screens/map_consumer.dart';
 import 'package:gruene_app/features/campaigns/widgets/close_save_widget.dart';
@@ -33,7 +34,7 @@ class PosterEdit extends StatefulWidget {
   State<PosterEdit> createState() => _PosterEditState();
 }
 
-class _PosterEditState extends State<PosterEdit> with AddressMixin {
+class _PosterEditState extends State<PosterEdit> with AddressMixin, ConfirmDelete {
   Set<PosterStatus> _segmentedButtonSelection = <PosterStatus>{};
 
   @override
@@ -248,7 +249,7 @@ class _PosterEditState extends State<PosterEdit> with AddressMixin {
           Container(
             padding: EdgeInsets.only(top: 6, bottom: 24),
             child: DeleteAndSaveWidget(
-              onDelete: _onDeletePressed,
+              onDelete: () => confirmDelete(context, _onDeletePressed),
               onSave: _savePoster,
             ),
           ),
@@ -285,56 +286,6 @@ class _PosterEditState extends State<PosterEdit> with AddressMixin {
   }
 
   void _onDeletePressed() async {
-    final theme = Theme.of(context);
-    final shouldDelete = await showDialog<bool>(
-      context: context,
-      barrierDismissible: true,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          backgroundColor: ThemeColors.alertBackground,
-          title: Center(
-            child: Text(
-              '${t.campaigns.posters.deletePoster.label}?',
-              style: theme.textTheme.titleMedium?.apply(color: theme.colorScheme.surface),
-            ),
-          ),
-          content: Text(
-            t.campaigns.posters.deletePoster.confirmation_dialog,
-            textAlign: TextAlign.center,
-            style: theme.textTheme.labelMedium?.apply(
-              color: theme.colorScheme.surface,
-              fontSizeDelta: 1,
-            ),
-          ),
-          actionsAlignment: MainAxisAlignment.spaceBetween,
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.maybePop(context, false),
-              child: Text(
-                t.common.actions.cancel,
-                style: theme.textTheme.labelLarge?.apply(color: ThemeColors.textCancel),
-              ),
-            ),
-            TextButton(
-              onPressed: () => Navigator.maybePop(context, true),
-              child: Text(
-                t.common.actions.delete,
-                style: theme.textTheme.labelLarge?.apply(
-                  color: ThemeColors.textWarning,
-                  fontWeightDelta: 2,
-                ),
-              ),
-            ),
-          ],
-        );
-      },
-    );
-    if (shouldDelete ?? false) {
-      _deleteAndReturn();
-    }
-  }
-
-  void _deleteAndReturn() {
     widget.onDelete(widget.poster.id);
     _closeDialog();
   }

--- a/lib/features/campaigns/widgets/delete_and_save_widget.dart
+++ b/lib/features/campaigns/widgets/delete_and_save_widget.dart
@@ -32,7 +32,7 @@ class DeleteAndSaveWidget extends StatelessWidget {
               ),
             ),
             child: Text(
-              t.campaigns.posters.deletePoster.label,
+              t.campaigns.deleteEntry.label,
               style: theme.textTheme.titleSmall?.apply(color: ThemeColors.textWarning),
             ),
           ),

--- a/lib/i18n/app_de.json
+++ b/lib/i18n/app_de.json
@@ -22,6 +22,7 @@
       "experience_areas": "Erfahrungsgebiete"
     },
     "posters": {
+      
       "label": "Plakate",
       "addPoster": "Plakat eintragen",
       "editPoster": "Plakat bearbeiten",
@@ -49,9 +50,7 @@
         "hint": "Bitte gib hierzu weitere Informationen an"
       },
       "deletePoster": {
-        "label": "Eintrag löschen",
-        "hint": "Bitte lösche Einträge ausschließlich, wenn es nicht anders geht. Markiere abgehängte Plakate als \"Abgehängt\".",
-        "confirmation_dialog": "Möchtest du diesen Eintrag wirklich löschen? Dies kann nicht rückgängig gemacht werden."
+        "hint": "Bitte lösche Einträge ausschließlich, wenn es nicht anders geht. Markiere abgehängte Plakate als \"Abgehängt\"."
       }
     },
     "door": {
@@ -72,6 +71,10 @@
       "countFlyer": "Anzahl der Flyer",
       "noFlyerWarning": "Bitte geben Sie mindestens einen Flyer ein!"
     },
+    "deleteEntry": {
+        "label": "Eintrag löschen",
+        "confirmation_dialog": "Möchtest du diesen Eintrag wirklich löschen? Dies kann nicht rückgängig gemacht werden."
+      },
     "team": {
       "label": "Team"
     },


### PR DESCRIPTION
### Short description

Confirmation dialog enabled for all delete actions

### Proposed changes

<!-- Describe this PR in more detail. -->

-
-

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #328 

---