### PR TITLE
366: integrate photo viewer for poster to enlarge pictures

### DIFF
--- a/lib/features/campaigns/screens/poster_edit.dart
+++ b/lib/features/campaigns/screens/poster_edit.dart
@@ -14,6 +14,7 @@ import 'package:gruene_app/features/campaigns/widgets/create_address_widget.dart
 import 'package:gruene_app/features/campaigns/widgets/delete_and_save_widget.dart';
 import 'package:gruene_app/features/campaigns/widgets/multiline_text_input_field.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
+import 'package:photo_view/photo_view.dart';
 
 typedef OnSavePosterCallback = void Function(PosterUpdateModel posterUpdate);
 
@@ -263,9 +264,12 @@ class _PosterEditState extends State<PosterEdit> with AddressMixin, ConfirmDelet
           PosterEdit.dummyAsset,
         );
     if (_currentPhoto != null) {
-      return Image.file(
-        _currentPhoto!,
-        fit: BoxFit.cover,
+      return GestureDetector(
+        onTap: _showPictureFullView,
+        child: Image.file(
+          _currentPhoto!,
+          fit: BoxFit.cover,
+        ),
       );
     }
     if (_isPhotoDeleted) return getDummyAsset();
@@ -276,10 +280,13 @@ class _PosterEditState extends State<PosterEdit> with AddressMixin, ConfirmDelet
           return getDummyAsset();
         }
 
-        return FadeInImage.assetNetwork(
-          placeholder: PosterEdit.dummyAsset,
-          image: snapshot.data!,
-          fit: BoxFit.cover,
+        return GestureDetector(
+          onTap: _showPictureFullView,
+          child: FadeInImage.assetNetwork(
+            placeholder: PosterEdit.dummyAsset,
+            image: snapshot.data!,
+            fit: BoxFit.cover,
+          ),
         );
       },
     );
@@ -378,5 +385,43 @@ class _PosterEditState extends State<PosterEdit> with AddressMixin, ConfirmDelet
         _currentPhoto = null;
       });
     }
+  }
+
+  void _showPictureFullView() async {
+    ImageProvider imageProvider;
+    if (_currentPhoto != null) {
+      imageProvider = FileImage(_currentPhoto!);
+    } else {
+      imageProvider = NetworkImage(widget.poster.imageUrl!);
+    }
+    final theme = Theme.of(context);
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      builder: (BuildContext context) {
+        return Stack(
+          children: [
+            Expanded(
+              child: PhotoView(
+                backgroundDecoration: BoxDecoration(color: ThemeColors.text.withAlpha(120)),
+                imageProvider: imageProvider,
+              ),
+            ),
+            Positioned(
+              right: 20,
+              top: 20,
+              child: GestureDetector(
+                onTap: () => Navigator.maybePop(context),
+                child: Icon(
+                  Icons.close,
+                  color: theme.colorScheme.surface,
+                  size: 30,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -853,6 +853,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  photo_view:
+    dependency: "direct main"
+    description:
+      name: photo_view
+      sha256: "1fc3d970a91295fbd1364296575f854c9863f225505c28c46e0a03e48960c75e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.0"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   image: ^4.3.0
   http_parser: ^4.0.2
   tuple: ^2.0.2
+  photo_view: ^0.15.0
 
 dev_dependencies:
 


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
We can now view photos in a separate enlarged photo_view

### Proposed changes

<!-- Describe this PR in more detail. -->

- tapping on the image in the poster edit form will show the photo_viewer

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- new gem photo_viewer
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #366

---