### PR TITLE
Use slang build runner in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,14 +186,11 @@ commands:
     prepare_project:
         steps:
             - run:
-                command: fvm dart run slang
-                name: Generate Translations
-            - run:
                 command: cp .env.prod .env
                 name: Apply Production Environment
             - run:
                 command: fvm dart run build_runner build
-                name: Generate Swagger API
+                name: Generate Swagger API and Translations
     prepare_workspace:
         description: Attach the workspace at ~/attached_workspace and list its contents
         steps:

--- a/.circleci/src/commands/prepare_project.yml
+++ b/.circleci/src/commands/prepare_project.yml
@@ -1,10 +1,7 @@
 steps:
   - run:
-      name: Generate Translations
-      command: fvm dart run slang
-  - run:
       name: Apply Production Environment
       command: cp .env.prod .env
   - run:
       command: fvm dart run build_runner build
-      name: Generate Swagger API
+      name: Generate Swagger API and Translations

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,18 @@
 targets:
   $default:
     sources:
+      - $package$
+      - lib/$lib$
       - swaggers/**
     builders:
+      slang_build_runner:
+        options:
+          base_locale: de
+          fallback_strategy: base_locale
+          input_file_pattern: .json
+          input_directory: lib/i18n
+          output_file_name: translations.g.dart
+          output_directory: lib/i18n
       chopper_generator:
         options:
           header: "// Generated code"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -966,18 +966,26 @@ packages:
     dependency: "direct main"
     description:
       name: slang
-      sha256: b04db2dbaf927b28600a2f8a272a3bf2ae309556dcc5d6beb02d66af0be39e4c
+      sha256: e02feadc1291280e755ed01da39817213247295368671da67570e28ac0120aa8
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.3.0"
+  slang_build_runner:
+    dependency: "direct dev"
+    description:
+      name: slang_build_runner
+      sha256: "9f5497fb1562bfbcf60ff10765d72e26d24fe29747d953756f110f0929503563"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
   slang_flutter:
     dependency: "direct main"
     description:
       name: slang_flutter
-      sha256: "59988f37bb8b50d96ee46832a8a389036c0da26c04b1b1d4aa6690c00f70eccf"
+      sha256: "493456b7c4f842ec2e7519c2358a4653b3198b84e9b2656b03a648f7f3405471"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.3.0"
   source_gen:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dev_dependencies:
   json_serializable: ^6.6.1
   swagger_dart_code_generator: ^3.0.1
 #---------------------------------------------------- 
+  slang_build_runner: ^4.3.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/slang.yaml
+++ b/slang.yaml
@@ -1,5 +1,0 @@
-base_locale: de
-fallback_strategy: base_locale
-input_file_pattern: .json
-input_directory: lib/i18n
-output_file_name: translations.g.dart


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Use slang build runner in CI. This gets rid of one config file and one command in the CI.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Use slang build runner in CI
- Delete slang.yaml

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Locally for development still use `fvm dart run slang` (due to https://github.com/slang-i18n/slang/issues/90)

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check that translations are still generated.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: None

---