### PR TITLE
217 use wheel slider

### DIFF
--- a/lib/app/services/converters.dart
+++ b/lib/app/services/converters.dart
@@ -6,6 +6,8 @@ import 'package:gruene_app/features/campaigns/models/map_layer_model.dart';
 import 'package:gruene_app/features/campaigns/models/marker_item_model.dart';
 import 'package:gruene_app/features/campaigns/models/posters/poster_detail_model.dart';
 import 'package:gruene_app/features/campaigns/models/posters/poster_list_item_model.dart';
+import 'package:gruene_app/features/campaigns/widgets/enhanced_wheel_slider.dart';
+import 'package:gruene_app/features/campaigns/widgets/text_input_field.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 import 'package:intl/intl.dart';
@@ -247,5 +249,31 @@ extension FocusAreaParsing on FocusArea {
 
     var coordList = polygon.coordinates.map(toPositionList).toList();
     return MapLayerModel(id: id, coords: coordList);
+  }
+}
+
+extension SliderRangeParsing on SliderInputRange {
+  InputFieldType getInputFieldType() {
+    return switch (this) {
+      SliderInputRange.numbers0To99 => InputFieldType.numbers0To99,
+      SliderInputRange.numbers0To999 => InputFieldType.numbers0To999,
+      SliderInputRange.numbers1To999 => InputFieldType.numbers1To999,
+    };
+  }
+
+  int getMinValue() {
+    return switch (this) {
+      SliderInputRange.numbers0To99 => 0,
+      SliderInputRange.numbers0To999 => 0,
+      SliderInputRange.numbers1To999 => 1,
+    };
+  }
+
+  int getMaxValue() {
+    return switch (this) {
+      SliderInputRange.numbers0To99 => 99,
+      SliderInputRange.numbers0To999 => 999,
+      SliderInputRange.numbers1To999 => 999,
+    };
   }
 }

--- a/lib/features/campaigns/helper/marker_item_helper.dart
+++ b/lib/features/campaigns/helper/marker_item_helper.dart
@@ -26,21 +26,24 @@ class MarkerItemHelper {
   }
 
   static Feature<Polygon> transformMapLayerModelToGeoJson(MapLayerModel mapLayerModel) {
-    final scoreColors = [
-      ThemeColors.primary.toHexStringRGB(),
-      ThemeColors.secondary.toHexStringRGB(),
-      ThemeColors.tertiary.toHexStringRGB(),
-    ];
+    // final scoreColors = [
+    //   ThemeColors.primary.toHexStringRGB(),
+    //   ThemeColors.secondary.toHexStringRGB(),
+    //   ThemeColors.tertiary.toHexStringRGB(),
+    // ];
     // debugPrint(scoreColors[0].toHexStringRGB());
     final random = Random();
-    final scoreColor = scoreColors[random.nextInt(scoreColors.length)];
+    var opacities = [0, 0.2, 0.35, 0.5, 0.65];
+    final scoreColor = ThemeColors.secondary.toHexStringRGB(); //scoreColors[random.nextInt(scoreColors.length)];
     return Feature<Polygon>(
       id: mapLayerModel.id,
       properties: <String, dynamic>{
         'id': mapLayerModel.id.toString(),
         // 'score_color': 'rgb(${scoreColor.red},${scoreColor.green},${scoreColor.blue})',
         'score_color': scoreColor,
-        'score_opacity': random.nextDouble() * 0.8,
+
+        'score_opacity': opacities[random.nextInt(opacities.length)],
+        // 'score_opacity': random.nextDouble() * 0.8,
       },
       geometry: Polygon(coordinates: mapLayerModel.coords),
     );

--- a/lib/features/campaigns/screens/door_edit.dart
+++ b/lib/features/campaigns/screens/door_edit.dart
@@ -7,7 +7,7 @@ import 'package:gruene_app/features/campaigns/screens/screen_extensions.dart';
 import 'package:gruene_app/features/campaigns/widgets/close_save_widget.dart';
 import 'package:gruene_app/features/campaigns/widgets/create_address_widget.dart';
 import 'package:gruene_app/features/campaigns/widgets/delete_and_save_widget.dart';
-import 'package:gruene_app/features/campaigns/widgets/text_input_field.dart';
+import 'package:gruene_app/features/campaigns/widgets/enhanced_wheel_slider.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 
 typedef OnSaveDoorCallback = Future<void> Function(DoorUpdateModel doorUpdate);
@@ -39,7 +39,6 @@ class _DoorEditState extends State<DoorEdit> with AddressExtension, DoorValidato
   TextEditingController cityTextController = TextEditingController();
 
   TextEditingController closedDoorTextController = TextEditingController();
-
   TextEditingController openedDoorTextController = TextEditingController();
 
   @override
@@ -54,8 +53,6 @@ class _DoorEditState extends State<DoorEdit> with AddressExtension, DoorValidato
     houseNumberTextController.text = widget.door.address.houseNumber;
     zipCodeTextController.text = widget.door.address.zipCode;
     cityTextController.text = widget.door.address.city;
-    openedDoorTextController.text = widget.door.openedDoors.toString();
-    closedDoorTextController.text = widget.door.closedDoors.toString();
     super.initState();
   }
 
@@ -89,24 +86,30 @@ class _DoorEditState extends State<DoorEdit> with AddressExtension, DoorValidato
             child: Row(
               children: [
                 Flexible(
-                  child: Container(
-                    padding: EdgeInsets.only(right: 6),
-                    child: TextInputField(
-                      labelText: t.campaigns.door.closedDoors,
-                      textController: closedDoorTextController,
-                      inputType: InputFieldType.numbers0To999,
-                      borderColor: lightBorderColor,
-                      selectAllTextOnFocus: true,
-                    ),
+                  child: EnhancedWheelSlider(
+                    labelText: t.campaigns.door.closedDoors,
+                    textController: closedDoorTextController,
+                    initialValue: widget.door.closedDoors,
+                    labelColor: ThemeColors.textDisabled,
+                    sliderColor: ThemeColors.text,
+                    borderColor: lightBorderColor,
+                    actionColor: theme.colorScheme.secondary,
+                    sliderInputRange: SliderInputRange.numbers0To999,
                   ),
                 ),
+                SizedBox(
+                  width: 10,
+                ),
                 Flexible(
-                  child: TextInputField(
+                  child: EnhancedWheelSlider(
                     labelText: t.campaigns.door.openedDoors,
+                    initialValue: widget.door.openedDoors,
                     textController: openedDoorTextController,
-                    inputType: InputFieldType.numbers0To999,
+                    labelColor: ThemeColors.textDisabled,
+                    sliderColor: ThemeColors.text,
                     borderColor: lightBorderColor,
-                    selectAllTextOnFocus: true,
+                    actionColor: theme.colorScheme.secondary,
+                    sliderInputRange: SliderInputRange.numbers0To999,
                   ),
                 ),
               ],

--- a/lib/features/campaigns/screens/doors_add_screen.dart
+++ b/lib/features/campaigns/screens/doors_add_screen.dart
@@ -3,8 +3,8 @@ import 'package:gruene_app/app/services/nominatim_service.dart';
 import 'package:gruene_app/features/campaigns/models/doors/door_create_model.dart';
 import 'package:gruene_app/features/campaigns/screens/screen_extensions.dart';
 import 'package:gruene_app/features/campaigns/widgets/create_address_widget.dart';
+import 'package:gruene_app/features/campaigns/widgets/enhanced_wheel_slider.dart';
 import 'package:gruene_app/features/campaigns/widgets/save_cancel_on_create_widget.dart';
-import 'package:gruene_app/features/campaigns/widgets/text_input_field.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 
@@ -27,6 +27,7 @@ class DoorsAddScreenState extends State<DoorsAddScreen> with AddressExtension, D
   TextEditingController zipCodeTextController = TextEditingController();
   @override
   TextEditingController cityTextController = TextEditingController();
+
   TextEditingController openedDoorTextController = TextEditingController();
   TextEditingController closedDoorTextController = TextEditingController();
 
@@ -88,22 +89,30 @@ class DoorsAddScreenState extends State<DoorsAddScreen> with AddressExtension, D
             child: Row(
               children: [
                 Flexible(
-                  child: Container(
-                    padding: EdgeInsets.only(right: 6),
-                    child: TextInputField(
-                      labelText: t.campaigns.door.closedDoors,
-                      textController: closedDoorTextController,
-                      inputType: InputFieldType.numbers0To999,
-                      selectAllTextOnFocus: true,
-                    ),
+                  child: EnhancedWheelSlider(
+                    labelText: t.campaigns.door.closedDoors,
+                    initialValue: 0,
+                    textController: closedDoorTextController,
+                    labelColor: theme.colorScheme.surface,
+                    sliderColor: theme.colorScheme.surface,
+                    borderColor: theme.colorScheme.surface,
+                    actionColor: theme.colorScheme.secondary,
+                    sliderInputRange: SliderInputRange.numbers0To999,
                   ),
                 ),
+                SizedBox(
+                  width: 10,
+                ),
                 Flexible(
-                  child: TextInputField(
+                  child: EnhancedWheelSlider(
                     labelText: t.campaigns.door.openedDoors,
+                    initialValue: 1,
                     textController: openedDoorTextController,
-                    inputType: InputFieldType.numbers0To999,
-                    selectAllTextOnFocus: true,
+                    labelColor: theme.colorScheme.surface,
+                    sliderColor: theme.colorScheme.surface,
+                    borderColor: theme.colorScheme.surface,
+                    actionColor: theme.colorScheme.secondary,
+                    sliderInputRange: SliderInputRange.numbers0To999,
                   ),
                 ),
               ],

--- a/lib/features/campaigns/screens/flyer_add_screen.dart
+++ b/lib/features/campaigns/screens/flyer_add_screen.dart
@@ -3,8 +3,8 @@ import 'package:gruene_app/app/services/nominatim_service.dart';
 import 'package:gruene_app/features/campaigns/models/flyer/flyer_create_model.dart';
 import 'package:gruene_app/features/campaigns/screens/screen_extensions.dart';
 import 'package:gruene_app/features/campaigns/widgets/create_address_widget.dart';
+import 'package:gruene_app/features/campaigns/widgets/enhanced_wheel_slider.dart';
 import 'package:gruene_app/features/campaigns/widgets/save_cancel_on_create_widget.dart';
-import 'package:gruene_app/features/campaigns/widgets/text_input_field.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 
@@ -75,11 +75,15 @@ class _FlyerAddScreenState extends State<FlyerAddScreen> with AddressExtension, 
                   child: SizedBox(),
                 ),
                 Flexible(
-                  child: TextInputField(
+                  child: EnhancedWheelSlider(
                     labelText: t.campaigns.flyer.countFlyer,
+                    initialValue: 1,
                     textController: flyerCountTextController,
-                    inputType: InputFieldType.numbers1To999,
-                    selectAllTextOnFocus: true,
+                    labelColor: theme.colorScheme.surface,
+                    sliderColor: theme.colorScheme.surface,
+                    borderColor: theme.colorScheme.surface,
+                    actionColor: theme.colorScheme.secondary,
+                    sliderInputRange: SliderInputRange.numbers1To999,
                   ),
                 ),
               ],

--- a/lib/features/campaigns/screens/flyer_edit.dart
+++ b/lib/features/campaigns/screens/flyer_edit.dart
@@ -7,7 +7,7 @@ import 'package:gruene_app/features/campaigns/screens/screen_extensions.dart';
 import 'package:gruene_app/features/campaigns/widgets/close_save_widget.dart';
 import 'package:gruene_app/features/campaigns/widgets/create_address_widget.dart';
 import 'package:gruene_app/features/campaigns/widgets/delete_and_save_widget.dart';
-import 'package:gruene_app/features/campaigns/widgets/text_input_field.dart';
+import 'package:gruene_app/features/campaigns/widgets/enhanced_wheel_slider.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 
 typedef OnSaveFlyerCallback = Future<void> Function(FlyerUpdateModel flyerUpdate);
@@ -81,12 +81,15 @@ class _FlyerEditState extends State<FlyerEdit> with AddressExtension, FlyerValid
                   child: SizedBox(),
                 ),
                 Flexible(
-                  child: TextInputField(
+                  child: EnhancedWheelSlider(
                     labelText: t.campaigns.flyer.countFlyer,
                     textController: flyerCountTextController,
-                    inputType: InputFieldType.numbers1To999,
+                    initialValue: widget.flyer.flyerCount,
+                    labelColor: ThemeColors.textDisabled,
+                    sliderColor: ThemeColors.text,
                     borderColor: lightBorderColor,
-                    selectAllTextOnFocus: true,
+                    actionColor: theme.colorScheme.secondary,
+                    sliderInputRange: SliderInputRange.numbers0To999,
                   ),
                 ),
               ],

--- a/lib/features/campaigns/widgets/enhanced_wheel_slider.dart
+++ b/lib/features/campaigns/widgets/enhanced_wheel_slider.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:gruene_app/app/services/converters.dart';
+import 'package:gruene_app/features/campaigns/widgets/text_input_field.dart';
+import 'package:wheel_slider/wheel_slider.dart';
+
+enum SliderInputRange { numbers0To99, numbers0To999, numbers1To999 }
+
+class EnhancedWheelSlider extends StatefulWidget {
+  final String labelText;
+  final int initialValue;
+  final TextEditingController textController;
+  final Color? labelColor;
+  final Color? borderColor;
+  final Color? sliderColor;
+  final Color? actionColor;
+  final SliderInputRange sliderInputRange;
+
+  const EnhancedWheelSlider({
+    super.key,
+    required this.labelText,
+    this.initialValue = 1,
+    required this.textController,
+    this.labelColor,
+    this.borderColor,
+    this.sliderColor,
+    this.actionColor,
+    this.sliderInputRange = SliderInputRange.numbers0To999,
+  });
+
+  @override
+  State<EnhancedWheelSlider> createState() => _EnhancedWheelSliderState();
+}
+
+class _EnhancedWheelSliderState extends State<EnhancedWheelSlider> {
+  int _nCurrentValue = 1;
+  // final TextEditingController _textController = TextEditingController();
+
+  bool showSlider = true;
+
+  late Color _borderColor;
+  late Color _labelColor;
+  late Color _sliderColor;
+  late Color _actionColor;
+
+  @override
+  void dispose() {
+    // _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    _borderColor = widget.borderColor ?? Colors.black;
+    _labelColor = widget.labelColor ?? Colors.black;
+    _sliderColor = widget.sliderColor ?? Colors.black;
+    _actionColor = widget.actionColor ?? Colors.black;
+
+    setState(() {
+      _nCurrentValue = widget.initialValue;
+    });
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        border: Border.all(color: _borderColor, width: 1),
+        borderRadius: BorderRadius.circular(5),
+      ),
+      child: Column(
+        children: [
+          Stack(
+            children: [
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  widget.labelText,
+                  style: theme.textTheme.labelMedium?.apply(
+                    color: _labelColor,
+                    fontWeightDelta: 5,
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment.centerRight,
+                child: GestureDetector(
+                  child: Icon(
+                    Icons.edit,
+                    size: 20,
+                    color: _sliderColor,
+                  ),
+                  onTap: () => setState(() {
+                    // switch
+                    if (!showSlider) {
+                      final val = int.tryParse(widget.textController.text) ?? _nCurrentValue;
+
+                      _nCurrentValue = val;
+                    }
+                    showSlider = !showSlider;
+                  }),
+                ),
+              ),
+            ],
+          ),
+          SizedBox(
+            height: 6,
+          ),
+          _showSliderOrTextInput(theme),
+        ],
+      ),
+    );
+  }
+
+  Widget _showSliderOrTextInput(ThemeData theme) {
+    final inputHeight = 55.0;
+    final iconSize = 30.0;
+    if (showSlider) {
+      return SizedBox(
+        height: inputHeight,
+        child: WheelSlider.number(
+          perspective: 0.01,
+          isInfinite: false,
+          totalCount: widget.sliderInputRange.getMaxValue(),
+          initValue: _nCurrentValue,
+          enableAnimation: false,
+          unSelectedNumberStyle: theme.textTheme.labelMedium?.apply(color: _labelColor),
+          selectedNumberStyle: theme.textTheme.labelMedium?.apply(
+            color: _sliderColor,
+            fontWeightDelta: 2,
+            fontSizeDelta: 2,
+          ),
+          currentIndex: _nCurrentValue,
+          onValueChanged: (val) {
+            setState(() {
+              _nCurrentValue = val as int;
+              widget.textController.text = _nCurrentValue.toString();
+            });
+          },
+          hapticFeedbackType: HapticFeedbackType.heavyImpact,
+        ),
+      );
+    } else {
+      return SizedBox(
+        height: inputHeight,
+        child: Row(
+          children: [
+            Container(
+              padding: EdgeInsets.only(top: 10),
+              child: GestureDetector(
+                onTap: () => _changeValue(-1),
+                child: Icon(
+                  Icons.remove_circle,
+                  size: iconSize,
+                  color: _actionColor,
+                ),
+              ),
+            ),
+            SizedBox(
+              width: 6,
+            ),
+            Expanded(
+              child: TextInputField(
+                labelText: widget.labelText,
+                textController: widget.textController,
+                inputType: widget.sliderInputRange.getInputFieldType(),
+                selectAllTextOnFocus: true,
+              ),
+            ),
+            SizedBox(
+              width: 6,
+            ),
+            Container(
+              padding: EdgeInsets.only(top: 10),
+              child: GestureDetector(
+                onTap: () => _changeValue(1),
+                child: Icon(
+                  Icons.add_circle,
+                  size: iconSize,
+                  color: _actionColor,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
+  void _changeValue(int increase) {
+    final val = int.tryParse(widget.textController.text) ?? _nCurrentValue;
+    var newValue = val + increase;
+
+    if (newValue > widget.sliderInputRange.getMaxValue() || newValue < widget.sliderInputRange.getMinValue()) return;
+
+    widget.textController.text = newValue.toString();
+    _nCurrentValue = newValue;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1298,6 +1298,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.16.2"
+  wheel_chooser:
+    dependency: transitive
+    description:
+      name: wheel_chooser
+      sha256: "3fee36f081f321c58a0b7b4afcdd92599f2ca520b3a1420084774e6b19cca1d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  wheel_slider:
+    dependency: "direct main"
+    description:
+      name: wheel_slider
+      sha256: "63a4cdfeb262d5c5bce2f59b6488b070c192960dcd789e9344a80e1e29ca6c2c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   http_parser: ^4.0.2
   tuple: ^2.0.2
   photo_view: ^0.15.0
+  wheel_slider: ^1.2.1
 
 dev_dependencies:
 


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Instead of TextField we can use a slider for user input, which is more suitable for mobile input.

### Proposed changes

<!-- Describe this PR in more detail. -->
- allow switch to text input
- use +/- buttons to increase by 1/-1 per tap

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- the package 'wheel_slider'
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---