### PR TITLE
183 use access token for api and refresh token when needed

### DIFF
--- a/lib/app/auth/repository/auth_repository.dart
+++ b/lib/app/auth/repository/auth_repository.dart
@@ -20,7 +20,7 @@ class AuthRepository {
           Config.oidcClientId,
           Config.oidcCallbackPath,
           issuer: Config.oidcIssuer,
-          scopes: ['openid', 'profile', 'email'],
+          scopes: ['openid', 'profile', 'email', 'offline_access'],
         ),
       );
 

--- a/lib/app/services/gruene_api_campaigns_service.dart
+++ b/lib/app/services/gruene_api_campaigns_service.dart
@@ -1,6 +1,9 @@
-import 'dart:typed_data';
+import 'dart:async';
+import 'dart:io';
 
 import 'package:chopper/chopper.dart' as chopper;
+import 'package:flutter/foundation.dart';
+import 'package:gruene_app/app/auth/repository/auth_repository.dart';
 import 'package:gruene_app/app/constants/config.dart';
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/enums.dart';
@@ -16,7 +19,7 @@ import 'package:gruene_app/features/campaigns/models/posters/poster_create_model
 import 'package:gruene_app/features/campaigns/models/posters/poster_detail_model.dart';
 import 'package:gruene_app/features/campaigns/models/posters/poster_update_model.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
-import 'package:http/http.dart';
+import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
 import 'package:intl/intl.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
@@ -29,7 +32,7 @@ class GrueneApiCampaignsService {
   final PoiServiceType poiType;
 
   GrueneApiCampaignsService({required this.poiType}) {
-    grueneApi = _GrueneApiCore().getService();
+    grueneApi = _GrueneApiCore().service;
   }
 
   Future<List<MarkerItemModel>> loadPoisInRegion(LatLng locationSW, LatLng locationNE) async {
@@ -39,6 +42,8 @@ class GrueneApiCampaignsService {
       type: getPoisType,
       bbox: locationSW.transformToGeoJsonBBoxString(locationNE),
     );
+    if (getPoisResult.error != null) debugPrint(getPoisResult.error!.toString());
+
     return getPoisResult.body!.data.map((p) => p.transformToMarkerItem()).toList();
   }
 
@@ -177,7 +182,7 @@ class GrueneApiCampaignsService {
     // ignore: unused_local_variable
     final savePoiPhotoResponse = await grueneApi.v1CampaignsPoisPoiIdPhotosPost(
       poiId: poiId,
-      image: MultipartFile.fromBytes(
+      image: http.MultipartFile.fromBytes(
         'image',
         photo,
         filename: 'poi_${poiId}_$timeStamp.jpg',

--- a/lib/app/services/gruene_api_core.dart
+++ b/lib/app/services/gruene_api_core.dart
@@ -2,21 +2,156 @@ part of 'gruene_api_campaigns_service.dart';
 
 class _GrueneApiCore {
   late GrueneApi _grueneApiService;
+  final _authRepository = AuthRepository();
 
   _GrueneApiCore() {
+    List<chopper.Interceptor> interceptors = [];
+    chopper.Authenticator? authenticator;
+
+    if (Config.gruenesNetzApiKey.isNotEmpty) {
+      interceptors.add(ApiKeyInterceptor());
+    } else {
+      authenticator = AccessTokenAuthenticator(_authRepository);
+      interceptors.add(AuthInterceptor(_authRepository));
+    }
+
     _grueneApiService = GrueneApi.create(
       baseUrl: Uri.parse(Config.gruenesNetzApiUrl),
-      interceptors: [
-        chopper.HeadersInterceptor(
-          {
-            'x-api-key': Config.gruenesNetzApiKey,
-          },
-        ),
-      ],
+      authenticator: authenticator,
+      interceptors: interceptors,
     );
   }
 
-  GrueneApi getService() {
-    return _grueneApiService;
+  GrueneApi get service => _grueneApiService;
+}
+
+class ApiKeyInterceptor implements chopper.Interceptor {
+  @override
+  FutureOr<chopper.Response<BodyType>> intercept<BodyType>(chopper.Chain<BodyType> chain) {
+    final updatedRequest = chopper.applyHeader(
+      chain.request,
+      'x-api-key',
+      Config.gruenesNetzApiKey,
+      // Do not override existing header
+      override: false,
+    );
+
+    return chain.proceed(updatedRequest);
   }
+}
+
+class _AuthConstants {
+  static const bearerPrefix = 'Bearer';
+}
+
+class AuthInterceptor implements chopper.Interceptor {
+  const AuthInterceptor(this._repo);
+
+  final AuthRepository _repo;
+
+  @override
+  FutureOr<chopper.Response<BodyType>> intercept<BodyType>(chopper.Chain<BodyType> chain) async {
+    var token = await _repo.getAccessToken();
+    final updatedRequest = chopper.applyHeader(
+      chain.request,
+      HttpHeaders.authorizationHeader,
+      '${_AuthConstants.bearerPrefix} ${token!}1',
+      // Do not override existing header
+      override: false,
+    );
+
+    debugPrint('[AuthInterceptor] accessToken: ${updatedRequest.headers[HttpHeaders.authorizationHeader]}');
+
+    return chain.proceed(updatedRequest);
+  }
+}
+
+//
+// Authenticator
+//
+class AccessTokenAuthenticator implements chopper.Authenticator {
+  AccessTokenAuthenticator(this._repo);
+
+  final AuthRepository _repo;
+
+  @override
+  FutureOr<chopper.Request?> authenticate(
+    chopper.Request request,
+    chopper.Response<dynamic> response, [
+    chopper.Request? originalRequest,
+  ]) async {
+    debugPrint('[MyAuthenticator] response.statusCode: ${response.statusCode}');
+    debugPrint('[MyAuthenticator] request Retry-Count: ${request.headers['Retry-Count'] ?? 0}');
+    debugPrint('OriginalRequest ${originalRequest.toString()}');
+    // 401
+    if (response.statusCode == HttpStatus.unauthorized) {
+      // Trying to update token only 1 time
+      if (request.headers['Retry-Count'] != null) {
+        debugPrint(
+          '[MyAuthenticator] Unable to refresh token, retry count exceeded',
+        );
+        return null;
+      }
+
+      try {
+        final newToken = await _refreshToken();
+
+        var updatedRequest = chopper.applyHeaders(
+          request,
+          {
+            HttpHeaders.authorizationHeader: '${_AuthConstants.bearerPrefix} ${newToken!}',
+            // Setting the retry count to not end up in an infinite loop of unsuccessful updates
+            'Retry-Count': '1',
+          },
+        );
+
+        debugPrint(
+          '[MyAuthenticator] accessToken: ${updatedRequest.headers[HttpHeaders.authorizationHeader]}',
+        );
+
+        return updatedRequest;
+      } catch (e) {
+        debugPrint('[MyAuthenticator] Unable to refresh token: $e');
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  // Completer to prevent multiple token refreshes at the same time
+  Completer<String?>? _completer;
+
+  Future<String?> _refreshToken() {
+    var completer = _completer;
+    if (completer != null && !completer.isCompleted) {
+      debugPrint('[MyAuthenticator] Token refresh is already in progress');
+      return completer.future;
+    }
+
+    completer = Completer<String?>();
+    _completer = completer;
+
+    _repo.refreshToken().then((success) {
+      debugPrint('[MyAuthenticator] RefreshStatus: $success');
+
+      if (success) {
+        // Completing with a new token
+        completer?.complete(_repo.getAccessToken());
+      } else {
+        completer?.completeError('Refresh token error', StackTrace.current);
+      }
+    }).onError((error, stackTrace) {
+      // Completing with an error
+      completer?.completeError(error ?? 'Refresh token error', stackTrace);
+    });
+
+    return completer.future;
+  }
+
+  @override
+  chopper.AuthenticationCallback? get onAuthenticationFailed => null;
+
+  @override
+  chopper.AuthenticationCallback? get onAuthenticationSuccessful => null;
 }


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
We can now use the API with the OIDC access token and also refresh it when necessary.

### Proposed changes

<!-- Describe this PR in more detail. -->

-
-

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- claim 'offline_access' added to the requested token scopes
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---