### PR TITLE
392: Refactor API Client Code

### DIFF
--- a/lib/app/services/gruene_api_campaigns_service.dart
+++ b/lib/app/services/gruene_api_campaigns_service.dart
@@ -1,10 +1,8 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:chopper/chopper.dart' as chopper;
 import 'package:flutter/foundation.dart';
-import 'package:gruene_app/app/auth/repository/auth_repository.dart';
-import 'package:gruene_app/app/constants/config.dart';
+import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/enums.dart';
 import 'package:gruene_app/features/campaigns/models/doors/door_create_model.dart';
@@ -25,15 +23,13 @@ import 'package:http_parser/http_parser.dart';
 import 'package:intl/intl.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 
-part 'gruene_api_core.dart';
-
 class GrueneApiCampaignsService {
   late GrueneApi grueneApi;
 
   final PoiServiceType poiType;
 
   GrueneApiCampaignsService({required this.poiType}) {
-    grueneApi = _GrueneApiCore().service;
+    grueneApi = GetIt.I<GrueneApi>();
   }
 
   Future<List<MarkerItemModel>> loadPoisInRegion(LatLng locationSW, LatLng locationNE) async {

--- a/lib/app/services/gruene_api_core.dart
+++ b/lib/app/services/gruene_api_core.dart
@@ -1,28 +1,29 @@
-part of 'gruene_api_campaigns_service.dart';
+import 'dart:async';
+import 'dart:io';
 
-class _GrueneApiCore {
-  late GrueneApi _grueneApiService;
-  final _authRepository = AuthRepository();
+import 'package:chopper/chopper.dart' as chopper;
+import 'package:flutter/foundation.dart';
+import 'package:gruene_app/app/auth/repository/auth_repository.dart';
+import 'package:gruene_app/app/constants/config.dart';
+import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
-  _GrueneApiCore() {
-    List<chopper.Interceptor> interceptors = [];
-    chopper.Authenticator? authenticator;
+GrueneApi createGrueneApiClient() {
+  List<chopper.Interceptor> interceptors = [];
+  chopper.Authenticator? authenticator;
 
-    if (Config.gruenesNetzApiKey.isNotEmpty) {
-      interceptors.add(ApiKeyInterceptor());
-    } else {
-      authenticator = AccessTokenAuthenticator(_authRepository);
-      interceptors.add(AuthInterceptor(_authRepository));
-    }
-
-    _grueneApiService = GrueneApi.create(
-      baseUrl: Uri.parse(Config.gruenesNetzApiUrl),
-      authenticator: authenticator,
-      interceptors: interceptors,
-    );
+  if (Config.gruenesNetzApiKey.isNotEmpty) {
+    interceptors.add(ApiKeyInterceptor());
+  } else {
+    AuthRepository repo = AuthRepository();
+    authenticator = AccessTokenAuthenticator(repo);
+    interceptors.add(AuthInterceptor(repo));
   }
 
-  GrueneApi get service => _grueneApiService;
+  return GrueneApi.create(
+    baseUrl: Uri.parse(Config.gruenesNetzApiUrl),
+    authenticator: authenticator,
+    interceptors: interceptors,
+  );
 }
 
 class ApiKeyInterceptor implements chopper.Interceptor {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,11 +5,14 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/auth/repository/auth_repository.dart';
 import 'package:gruene_app/app/router.dart';
+import 'package:gruene_app/app/services/gruene_api_core.dart';
 import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
+import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
 void main() async {
   await dotenv.load(fileName: '.env');
@@ -20,6 +23,8 @@ void main() async {
   if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
     await InAppWebViewController.setWebContentsDebuggingEnabled(kDebugMode);
   }
+
+  GetIt.I.registerSingleton<GrueneApi>(createGrueneApiClient());
 
   runApp(TranslationProvider(child: const MyApp()));
 }


### PR DESCRIPTION
* refactor `gruene_api_campaigns_service.dart` and `gruene_api_core.dart`
* register api client instance in `GetIt`

Fixes
#392 