### PR TITLE
421: fix using null values against the gruene api when value is empty

### DIFF
--- a/lib/app/services/converters.dart
+++ b/lib/app/services/converters.dart
@@ -129,10 +129,10 @@ extension PoiAddressParsing on PoiAddress {
   AddressModel transformToAddressModel() {
     final address = this;
     return AddressModel(
-      street: address.street,
-      houseNumber: address.houseNumber,
-      zipCode: address.zip,
-      city: address.city,
+      street: address.street ?? '',
+      houseNumber: address.houseNumber ?? '',
+      zipCode: address.zip ?? '',
+      city: address.city ?? '',
     );
   }
 }
@@ -141,10 +141,10 @@ extension AddressModelParsing on AddressModel {
   PoiAddress transformToPoiAddress() {
     final address = this;
     return PoiAddress(
-      city: address.city,
-      zip: address.zipCode,
-      street: address.street,
-      houseNumber: address.houseNumber,
+      city: address.city.isEmpty ? null : address.city,
+      zip: address.zipCode.isEmpty ? null : address.zipCode,
+      street: address.street.isEmpty ? null : address.street,
+      houseNumber: address.houseNumber.isEmpty ? null : address.houseNumber,
     );
   }
 }
@@ -168,7 +168,7 @@ extension PoiParsing on Poi {
     }
     return DoorDetailModel(
       id: poi.id,
-      address: poi.address!.transformToAddressModel(),
+      address: poi.address.transformToAddressModel(),
       openedDoors: poi.house!.countOpenedDoors.toInt(),
       closedDoors: poi.house!.countClosedDoors.toInt(),
     );
@@ -183,7 +183,7 @@ extension PoiParsing on Poi {
       id: poi.id,
       thumbnailUrl: _getThumbnailImageUrl(poi),
       imageUrl: _getImageUrl(poi),
-      address: poi.address!.transformToAddressModel(),
+      address: poi.address.transformToAddressModel(),
       status: poi.poster!.status.transformToModelPosterStatus(),
       comment: poi.poster!.comment ?? '',
     );
@@ -196,7 +196,7 @@ extension PoiParsing on Poi {
     }
     return FlyerDetailModel(
       id: poi.id,
-      address: poi.address!.transformToAddressModel(),
+      address: poi.address.transformToAddressModel(),
       flyerCount: poi.flyerSpot!.flyerCount.toInt(),
     );
   }
@@ -210,7 +210,7 @@ extension PoiParsing on Poi {
       id: poi.id,
       thumbnailUrl: _getThumbnailImageUrl(poi),
       imageUrl: _getImageUrl(poi),
-      address: poi.address!.transformToAddressModel(),
+      address: poi.address.transformToAddressModel(),
       status: poi.poster!.status.translatePosterStatus(),
       lastChangeStatus: poi._getLastChangeStatus(),
       lastChangeDateTime: poi._getLastChangeDateTimeInfo(),

--- a/lib/app/services/gruene_api_campaigns_service.dart
+++ b/lib/app/services/gruene_api_campaigns_service.dart
@@ -133,7 +133,7 @@ class GrueneApiCampaignsService {
       address: posterUpdate.address.transformToPoiAddress(),
       poster: PoiPoster(
         status: posterUpdate.status.transformToPoiPosterStatus(),
-        comment: posterUpdate.comment,
+        comment: posterUpdate.comment.isEmpty ? null : posterUpdate.comment,
       ),
     );
     var updatePoiResponse = await grueneApi.v1CampaignsPoisPoiIdPut(poiId: posterUpdate.id, body: dtoUpdate);

--- a/swaggers/gruene-api.yaml
+++ b/swaggers/gruene-api.yaml
@@ -1676,6 +1676,8 @@ tags: []
 servers:
   - url: https://api.gruene.de
     description: Production
+  - url: http://192.168.178.95:5000
+    description: Development
 components:
   securitySchemes:
     basic:
@@ -3014,20 +3016,28 @@ components:
       properties:
         city:
           type: string
+          nullable: true
           description: Location city
           example: Berlin
+          minLength: 1
         zip:
           type: string
+          nullable: true
           description: Location zip code
           example: '10176'
+          minLength: 1
         street:
           type: string
+          nullable: true
           description: First address line for street and house number
           example: Bahnhofstraße
+          minLength: 1
         houseNumber:
           type: string
+          nullable: true
           description: First address line for street and house number
           example: 12/a
+          minLength: 1
       required:
         - city
         - zip
@@ -3080,9 +3090,7 @@ components:
       type: object
       properties:
         address:
-          nullable: true
-          allOf:
-            - $ref: '#/components/schemas/PoiAddress'
+          $ref: '#/components/schemas/PoiAddress'
         poster:
           nullable: true
           allOf:
@@ -3095,6 +3103,8 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/PoiHouse'
+      required:
+        - address
     CreatePoi:
       type: object
       properties:
@@ -3115,9 +3125,7 @@ components:
             - HOUSE
           type: string
         address:
-          nullable: true
-          allOf:
-            - $ref: '#/components/schemas/PoiAddress'
+          $ref: '#/components/schemas/PoiAddress'
         poster:
           nullable: true
           allOf:
@@ -3133,6 +3141,7 @@ components:
       required:
         - coords
         - type
+        - address
     Image:
       type: object
       properties:
@@ -3211,9 +3220,7 @@ components:
           items:
             $ref: '#/components/schemas/ImageSrcSet'
         address:
-          nullable: true
-          allOf:
-            - $ref: '#/components/schemas/PoiAddress'
+          $ref: '#/components/schemas/PoiAddress'
         type:
           enum:
             - FLYER_SPOT


### PR DESCRIPTION

### Short description

<!-- Describe this PR in one or two sentences. -->
We use now an updated API, where the address shouldn't be null. We also change now, that empty strings are not transmitted, when not necessary to satisfy the needs of the API.

### Proposed changes

<!-- Describe this PR in more detail. -->

-
-

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #421

---