### PR TITLE
418: create a custom bottom actions bar to get a cancel button

### DIFF
--- a/lib/features/campaigns/helper/media_helper.dart
+++ b/lib/features/campaigns/helper/media_helper.dart
@@ -18,6 +18,27 @@ class MediaHelper {
         builder: (context) {
           return CameraAwesomeBuilder.awesome(
             saveConfig: SaveConfig.photo(),
+            bottomActionsBuilder: (state) => AwesomeBottomActions(
+              state: state,
+              left: AwesomeCameraSwitchButton(
+                state: state,
+                scale: 1.0,
+                onSwitchTap: (state) {
+                  state.switchCameraSensor(
+                    aspectRatio: state.sensorConfig.aspectRatio,
+                  );
+                },
+              ),
+              right: GestureDetector(
+                onTap: () => Navigator.maybePop(context),
+                child: Icon(
+                  Icons.close,
+                  size: 40,
+                  color: ThemeColors.background,
+                ),
+              ),
+            ),
+            availableFilters: [],
             onMediaCaptureEvent: (mediaCapture) async {
               if (mediaCapture.status == MediaCaptureStatus.success) {
                 final imageFile = File(mediaCapture.captureRequest.path!);


### PR DESCRIPTION
### Short description

create a custom bottom actions bar to get a cancel button on the bottom right (helps ios users to cancel photo-operation)

### Proposed changes

<!-- Describe this PR in more detail. -->

-
-

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #418 

---