### PR TITLE
418 show cancel button for photos only on ios

### DIFF
--- a/lib/features/campaigns/helper/media_helper.dart
+++ b/lib/features/campaigns/helper/media_helper.dart
@@ -29,14 +29,7 @@ class MediaHelper {
                   );
                 },
               ),
-              right: GestureDetector(
-                onTap: () => Navigator.maybePop(context),
-                child: Icon(
-                  Icons.close,
-                  size: 40,
-                  color: ThemeColors.background,
-                ),
-              ),
+              right: _getCloseButton(context),
             ),
             availableFilters: [],
             onMediaCaptureEvent: (mediaCapture) async {
@@ -50,6 +43,19 @@ class MediaHelper {
       ),
     );
     return image;
+  }
+
+  static Widget? _getCloseButton(BuildContext context) {
+    if (!Platform.isIOS) return null;
+
+    return GestureDetector(
+      onTap: () => Navigator.maybePop(context),
+      child: Icon(
+        Icons.close,
+        size: 40,
+        color: ThemeColors.background,
+      ),
+    );
   }
 
   static Future<Uint8List?> resizeAndReduceImageFile(File? photo) async {


### PR DESCRIPTION
### Short description

shows the cancel button for photos only on ios

### Proposed changes

<!-- Describe this PR in more detail. -->

-
-

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #418 

---