### PR TITLE
432: get gps position gracefully

### DIFF
--- a/lib/features/campaigns/widgets/map_with_location.dart
+++ b/lib/features/campaigns/widgets/map_with_location.dart
@@ -27,7 +27,7 @@ class MapWithLocation extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: determinePosition(context, requestIfNotGranted: false)
+      future: determinePosition(context, requestIfNotGranted: false, preferLastKnownPosition: true)
           .timeout(const Duration(milliseconds: 400), onTimeout: () => RequestedPosition.unknown()),
       builder: (context, AsyncSnapshot<RequestedPosition> snapshot) {
         if (!snapshot.hasData && !snapshot.hasError) {


### PR DESCRIPTION
### Short description

Improved Acquiring GPS Position
- more graceful handling of some egde cases
- not use last_known_location with such a high priority
- fallback in getting current_location if user has disabled location accuracy
- allow gps 30seconds to calibrate before canceling operation

<!-- Describe this PR in one or two sentences. -->

### Proposed changes

<!-- Describe this PR in more detail. -->

-
-

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #419 
Fixes: #432 

---