### PR TITLE
459: show info toast for focus area

### DIFF
--- a/lib/features/campaigns/screens/screen_extensions.dart
+++ b/lib/features/campaigns/screens/screen_extensions.dart
@@ -154,3 +154,53 @@ mixin PosterValidator {
     return true;
   }
 }
+
+mixin FocusAreaInfo {
+  void showAboutFocusArea(BuildContext context) async {
+    final theme = Theme.of(context);
+    await showDialog<bool>(
+      context: context,
+      barrierDismissible: true,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          backgroundColor: ThemeColors.backgroundSecondary,
+          title: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.info,
+                color: ThemeColors.textCancel,
+              ),
+              SizedBox(width: 6),
+              Text(
+                t.campaigns.infoToast.focusAreas_aboutTitle,
+                style: theme.textTheme.titleMedium?.apply(color: ThemeColors.textDark),
+              ),
+            ],
+          ),
+          content: Text(
+            t.campaigns.infoToast.focusAreas_aboutText,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.labelMedium?.apply(
+              color: ThemeColors.textDark,
+              fontSizeDelta: 1,
+            ),
+          ),
+          actionsAlignment: MainAxisAlignment.end,
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.maybePop(context),
+              child: Text(
+                t.common.actions.close,
+                style: theme.textTheme.labelLarge?.apply(
+                  color: ThemeColors.textDark,
+                  fontWeightDelta: 2,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/i18n/app_de.json
+++ b/lib/i18n/app_de.json
@@ -9,7 +9,8 @@
       "delete": "Löschen",
       "edit": "Bearbeiten",
       "settings": "Einstellungen",
-      "openSettings": "Einstellungen öffnen"
+      "openSettings": "Einstellungen öffnen",
+      "close": "Schließen"
     }
   },
   "news": {
@@ -33,6 +34,13 @@
       "visited_areas": "Besuchte Gebiete",
       "polling_stations": "Wahllokale",
       "experience_areas": "Erfahrungsgebiete"
+    },
+    "infoToast": {
+      "focusAreas_activated": "Fokusgebiete aktiviert",
+      "focusAreas_deactivated": "Fokusgebiete deaktiviert",
+      "focusAreas_aboutTitle": "Über Fokusgebiete",
+      "focusAreas_aboutText": "Fokusgebiete zeigen Dir, wo sich Wahlkampf in welcher Form besonders lohnt. Diese Fokusgebiete sind in Level 1 (wenig) bis 5 (viel) aufgeteilt.\nKlicke auf ein Fokusgebiet, um mehr Infos zu erhalten.",
+      "more": "mehr Info"
     },
     "poster": {
       "label": "Plakat",


### PR DESCRIPTION

### Short description

- when activating focus areas a toast pop ups
- tapping shows info text for focus area

<!-- Describe this PR in one or two sentences. -->

### Proposed changes

<!-- Describe this PR in more detail. -->

-
-

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #459

---