### PR TITLE
Fix iOS Build with mobile_scanner

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -976,10 +976,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: "728828a798d1a2ee506beb652ca23d974c542c96ed03dcbd5eaf97bef96cdaad"
+      sha256: dd2d1638ed60a0e04fb9fdff3da25da6a464812a7d6760b056de6b5f6893b48e
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "7.0.0-beta.3"
   motion_toast:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   motion_toast: ^2.11.0
   keycloak_authenticator:
     path: ./packages/keycloak_authenticator
-  mobile_scanner: ^6.0.2
+  mobile_scanner: ^7.0.0-beta.3
   timeago: ^3.7.0
   local_auth: ^2.3.0
   image_picker: ^1.1.2


### PR DESCRIPTION
* use beta version `7.0.0-beta.3` of mobile_scanner to allow iOS Build with target `MinimumOSVersion=12`