### PR TITLE
503: Add 2fa improvements

### DIFF
--- a/lib/app/constants/urls.dart
+++ b/lib/app/constants/urls.dart
@@ -2,6 +2,8 @@ const legalNoticeUrl = 'https://www.gruene.de/service/impressum';
 const dataProtectionStatementUrl = 'https://www.gruene.de/service/datenschutz';
 const termsOfUseUrl = 'https://www.gruene.de/service/nutzungsbedingungen';
 const supportUrl = 'https://www.gruene.de/unterstuetzen';
+const mfaSettingsUrl = 'https://saml.gruene.de/realms/gruenes-netz/account/account-security/signing-in';
+const mfaInformationUrl = 'https://gruenstreifen.netzbegruenung.de/anmelden-im-gruenen-netz/anleitung-2fa-via-app';
 
 const grueneSupportMail = 'beteiligung@gruene.de';
 const pollionSupportMail = 'support@pollion.com';

--- a/lib/app/widgets/app_bar.dart
+++ b/lib/app/widgets/app_bar.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/constants/routes.dart';
 import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/app/widgets/icon.dart';
@@ -10,6 +12,8 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     final currentRoute = GoRouterState.of(context);
+    final authBloc = context.read<AuthBloc>();
+    final isLoggedIn = authBloc.state is Authenticated;
     final theme = Theme.of(context);
     return AppBar(
       title: Text(
@@ -28,7 +32,7 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
             ),
             onPressed: null,
           ),
-        if (currentRoute.path != Routes.settings.path)
+        if (currentRoute.path != Routes.settings.path && isLoggedIn)
           IconButton(
             icon: CustomIcon(
               path: 'assets/icons/settings.svg',

--- a/lib/features/mfa/widgets/intro_view.dart
+++ b/lib/features/mfa/widgets/intro_view.dart
@@ -2,9 +2,10 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:gruene_app/app/constants/routes.dart';
+import 'package:gruene_app/app/constants/urls.dart';
 import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/app/utils/open_url.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
-import 'package:url_launcher/url_launcher_string.dart';
 
 class IntroView extends StatelessWidget {
   const IntroView({super.key});
@@ -32,8 +33,18 @@ class IntroView extends StatelessWidget {
             style: theme.textTheme.bodyMedium,
           ),
           const SizedBox(height: 16),
-          Text(
-            t.mfa.intro.info.scanQRCode,
+          Text.rich(
+            t.mfa.intro.info.scanQRCode(
+              openMfaSettings: (text) => TextSpan(
+                text: text,
+                style: theme.textTheme.bodyMedium?.apply(
+                  color: ThemeColors.primary,
+                  decoration: TextDecoration.underline,
+                  fontWeightDelta: 3,
+                ),
+                recognizer: TapGestureRecognizer()..onTap = () => openUrl(mfaSettingsUrl, context),
+              ),
+            ),
             style: theme.textTheme.bodyMedium,
           ),
           const SizedBox(height: 16),
@@ -58,36 +69,20 @@ class IntroView extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 22),
-          RichText(
-            textAlign: TextAlign.center,
-            text: TextSpan(
-              text: t.mfa.intro.moreInformation.text,
-              style: theme.textTheme.labelSmall,
-              children: [
-                TextSpan(
-                  text: ' ',
-                  style: theme.textTheme.labelSmall,
-                ),
-                TextSpan(
-                  text: t.mfa.intro.moreInformation.link,
+          Center(
+            child: Text.rich(
+              t.mfa.intro.moreInformation(
+                openMfaInformation: (text) => TextSpan(
+                  text: text,
                   style: theme.textTheme.labelSmall?.apply(
                     color: ThemeColors.primary,
                     decoration: TextDecoration.underline,
                     fontWeightDelta: 3,
                   ),
-                  recognizer: TapGestureRecognizer()
-                    ..onTap = () {
-                      launchUrlString(
-                        'https://netz.gruene.de/de/wissenswerk/2024-02/2-faktor-authentifizierung-mit-einer-app-anleitung',
-                        mode: LaunchMode.externalApplication,
-                      );
-                    },
+                  recognizer: TapGestureRecognizer()..onTap = () => openUrl(mfaInformationUrl, context),
                 ),
-                TextSpan(
-                  text: t.mfa.intro.moreInformation.point,
-                  style: theme.textTheme.labelSmall,
-                ),
-              ],
+              ),
+              style: theme.textTheme.labelSmall,
             ),
           ),
         ],

--- a/lib/i18n/app_de.json
+++ b/lib/i18n/app_de.json
@@ -97,7 +97,7 @@
     },
     "deleteEntry": {
       "label": "Eintrag löschen",
-      "confirmation_dialog": "Möchtest du diesen Eintrag wirklich löschen? Dies kann nicht rückgängig gemacht werden."
+      "confirmation_dialog": "Möchtest Du diesen Eintrag wirklich löschen? Dies kann nicht rückgängig gemacht werden."
     },
     "team": {
       "label": "Team"
@@ -114,7 +114,7 @@
   },
   "location": {
     "activateLocationAccess": "Standortermittlung aktivieren",
-    "activateLocationAccessRationale": "Erlaube der App deinen Standort zu benutzen, um diesen auf der Karte anzuzeigen.",
+    "activateLocationAccessRationale": "Erlaube der App Deinen Standort zu benutzen, um diesen auf der Karte anzuzeigen.",
     "activateLocationAccessSettings": "Aktiviere die Standortermittlung in den Einstellungen.",
     "askPermissionsAgain": "Soll noch einmal nach der Berechtigung gefragt werden?",
     "grantLocation": "Ich möchte meinen Standort freigeben.",
@@ -136,21 +136,17 @@
       "info": {
         "easyLogin": "Mit der Zwei-Faktor-Authentifizierung kannst Du Dich ganz einfach im Grünen Netz einloggen.",
         "noShortMessageNeeded": "Kein Code per SMS mehr notwendig!",
-        "scanQRCode": "Zur Einrichtung des zweiten Faktors musst du nur mit deiner Kamera den QR-Code in den Einstellungen deines Grünes Netz-Accounts einscannen.",
-        "notificationOnLogin": "Danach erhältst Du bei jeder Anmeldung automatisch eine Benachrichtigung zur Freigabe der Anmeldung."
+        "scanQRCode(rich)": "Zur Einrichtung des zweiten Faktors musst Du nur mit Deiner Kamera den QR-Code in den ${openMfaSettings(Einstellungen Deines Grünen Netz-Accounts)} einscannen.",
+        "notificationOnLogin": "Im Anschluss öffne die App jedes mal, wenn du eine Anmeldung im Grünen Netz freigeben willst."
       },
       "startSetup": "Jetzt einrichten",
-      "moreInformation": {
-        "text": "Mehr Informationen zur Einrichtung findest du",
-        "link": "hier",
-        "point": "."
-      }
+      "moreInformation(rich)": "Mehr Informationen zur Einrichtung findest Du ${openMfaInformation(hier)}."
     },
     "tokenScan": {
       "title": "2FA - QR-Code scannen",
       "intro": "Scanne den QR-Code des Accounts, für den Du den zweiten Faktor aktivieren willst.",
       "doManual": "Einrichtungsschlüssel manuell eingeben",
-      "oidcIssuerMissmatch": "Die Authenticator-Funktion kann nur mit dem Grüne Netz verwendet werden."
+      "oidcIssuerMissmatch": "Die Authenticator-Funktion kann nur mit dem Grünen Netz verwendet werden."
     },
     "tokenInput": {
       "title": "2FA - Manuelle Einrichtung",
@@ -169,7 +165,7 @@
       "betaVersion": "Diese Funktion befindet sich noch in der Entwicklung. Wir bitten um Verständnis.",
       "delete": {
         "title": "App als zweiten Faktor deaktivieren",
-        "text": "Bitte entferne die App in deiner Account Console bevor du sie hier als zweiten Faktor deaktivierst. Sollte diese App dein einziger konfigurierter zweiter Faktor sein, wirst du dich ansonsten nach dem Deaktivieren nicht mehr einloggen können.",
+        "text": "Bitte entferne die App in Deiner Account Console bevor Du sie hier als zweiten Faktor deaktivierst. Sollte diese App Dein einziger konfigurierter zweiter Faktor sein, wirst Du dich ansonsten nach dem Deaktivieren nicht mehr einloggen können.",
         "submit": "Jetzt deaktivieren"
       }
     },


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Fix all things mentioned in #503 except `6. When I logout and try to login again, I can't use the App for 2FA. That's a conceptual problem we need to figure out`. Additional clarification is needed there.

### Proposed changes

<!-- Describe this PR in more detail. -->

Tasks described in #503:
1. Make `Einstellungen deines Grünen Netz-Accounts` clickable and link directly to https://saml.gruene.de/realms/gruenes-netz/account/account-security/signing-in
2. Fix `du/deine` to `Du/Deine`
3. Replace notification sentence with `Im Anschluss öffne die App jedes mal, wenn du eine Anmeldung im Grünen Netz freigeben willst.`
4. Replace old url with https://gruenstreifen.netzbegruenung.de/anmelden-im-gruenen-netz/anleitung-2fa-via-app/
5. Fix typo with `Grüne[n] Netz`

Additional:
- Hide settings button if not logged in
- Change `in den Einstellungen deines GrüneS] Netz-Accounts` to `in den Einstellungen deines Grünen Netz-Accounts`

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Have a look at the 2fa screen and press the links.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #503

### Additional information

<img src="https://github.com/user-attachments/assets/9a9017e0-f383-41fb-a173-11da9d6e3c78" width="400px" />

---