### PR TITLE
541: Make 2fa intro screen scrollable to allow for setting up 2fa

### DIFF
--- a/.idea/gruene_app.iml
+++ b/.idea/gruene_app.iml
@@ -8,6 +8,9 @@
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/.fvm" />
       <excludeFolder url="file://$MODULE_DIR$/ios/.symlinks" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/keycloak_authenticator/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/keycloak_authenticator/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/keycloak_authenticator/build" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/lib/features/mfa/widgets/intro_view.dart
+++ b/lib/features/mfa/widgets/intro_view.dart
@@ -14,70 +14,62 @@ class IntroView extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.fromLTRB(24, 33, 24, 26),
+      padding: const EdgeInsets.only(left: 24, right: 24, bottom: 24),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Text(
-            t.mfa.intro.title,
-            textAlign: TextAlign.center,
-            style: theme.textTheme.displayLarge,
-          ),
-          const SizedBox(height: 48),
-          Text(
-            t.mfa.intro.info.easyLogin,
-            style: theme.textTheme.bodyMedium?.apply(fontWeightDelta: 3),
-          ),
-          Text(
-            t.mfa.intro.info.noShortMessageNeeded,
-            style: theme.textTheme.bodyMedium,
-          ),
-          const SizedBox(height: 16),
-          Text.rich(
-            t.mfa.intro.info.scanQRCode(
-              openMfaSettings: (text) => TextSpan(
-                text: text,
-                style: theme.textTheme.bodyMedium?.apply(
-                  color: ThemeColors.primary,
-                  decoration: TextDecoration.underline,
-                  fontWeightDelta: 3,
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.only(top: 32, bottom: 16),
+              children: [
+                Text(
+                  t.mfa.intro.title,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.displayLarge,
                 ),
-                recognizer: TapGestureRecognizer()..onTap = () => openUrl(mfaSettingsUrl, context),
-              ),
+                const SizedBox(height: 48),
+                Text(
+                  t.mfa.intro.info.easyLogin,
+                  style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
+                ),
+                Text(t.mfa.intro.info.noShortMessageNeeded, style: theme.textTheme.bodyMedium),
+                const SizedBox(height: 16),
+                Text.rich(
+                  t.mfa.intro.info.scanQRCode(
+                    openMfaSettings: (text) => TextSpan(
+                      text: text,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: ThemeColors.primary,
+                        decoration: TextDecoration.underline,
+                        fontWeight: FontWeight.w700,
+                      ),
+                      recognizer: TapGestureRecognizer()..onTap = () => openUrl(mfaSettingsUrl, context),
+                    ),
+                  ),
+                  style: theme.textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 16),
+                Text(t.mfa.intro.info.notificationOnLogin, style: theme.textTheme.bodyMedium),
+              ],
             ),
-            style: theme.textTheme.bodyMedium,
           ),
-          const SizedBox(height: 16),
-          Text(
-            t.mfa.intro.info.notificationOnLogin,
-            style: theme.textTheme.bodyMedium,
-          ),
-          const SizedBox(height: 16),
-          Spacer(),
           FilledButton(
-            onPressed: () => {
-              context.push(
-                '${Routes.mfa.path}/${Routes.mfaTokenScan.path}',
-              ),
-            },
-            style: ButtonStyle(
-              minimumSize: WidgetStateProperty.all<Size>(Size.fromHeight(56)),
-            ),
+            onPressed: () => context.push('${Routes.mfa.path}/${Routes.mfaTokenScan.path}'),
+            style: ButtonStyle(minimumSize: WidgetStateProperty.all(Size.fromHeight(56))),
             child: Text(
               t.mfa.intro.startSetup,
               style: theme.textTheme.titleMedium?.apply(color: theme.colorScheme.surface),
             ),
           ),
-          const SizedBox(height: 22),
+          const SizedBox(height: 24),
           Center(
             child: Text.rich(
               t.mfa.intro.moreInformation(
                 openMfaInformation: (text) => TextSpan(
                   text: text,
-                  style: theme.textTheme.labelSmall?.apply(
+                  style: theme.textTheme.labelSmall?.copyWith(
                     color: ThemeColors.primary,
                     decoration: TextDecoration.underline,
-                    fontWeightDelta: 3,
+                    fontWeight: FontWeight.w700,
                   ),
                   recognizer: TapGestureRecognizer()..onTap = () => openUrl(mfaInformationUrl, context),
                 ),


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Make 2fa intro screen scrollable to allow for setting up 2fa.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Wrap the info text in a list view to allow for scrolling
- Keep the setup button at the bottom
- Use explicit fontWeight over fontWeightDelta

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test with both small and big devices to assure it looks good and is usable in both cases.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #541 

---