### PR TITLE
Use clean layout for 2fa if not logged in

### DIFF
--- a/assets/icons/back.svg
+++ b/assets/icons/back.svg
@@ -1,3 +1,0 @@
-<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M16.5416 29.375L17.9166 28.0417L10.7499 20.875H32.8333V19H10.7499L17.9583 11.7917L16.5833 10.5L7.12492 19.9167L16.5416 29.375Z" fill="white"/>
-</svg>

--- a/lib/app/theme/theme.dart
+++ b/lib/app/theme/theme.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 class ThemeColors {
@@ -165,9 +164,6 @@ final ThemeData appTheme = ThemeData.light().copyWith(
     unselectedLabelStyle: _ThemeTextStyles.labelSmall,
   ),
   scaffoldBackgroundColor: ThemeColors.backgroundSecondary,
-  actionIconTheme: ActionIconThemeData(
-    backButtonIconBuilder: (BuildContext context) => SvgPicture.asset('assets/icons/back.svg'),
-  ),
   tabBarTheme: TabBarTheme(
     indicatorColor: ThemeColors.primary,
     indicatorSize: TabBarIndicatorSize.tab,

--- a/lib/app/widgets/app_bar.dart
+++ b/lib/app/widgets/app_bar.dart
@@ -18,10 +18,10 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       title: Text(
         currentRoute.name ?? '',
-        style: theme.textTheme.displayMedium?.apply(color: theme.colorScheme.surface),
+        style: theme.textTheme.displayMedium?.apply(color: isLoggedIn ? theme.colorScheme.surface : ThemeColors.text),
       ),
-      foregroundColor: theme.colorScheme.surface,
-      backgroundColor: theme.primaryColor,
+      foregroundColor: isLoggedIn ? theme.colorScheme.surface : ThemeColors.text,
+      backgroundColor: isLoggedIn ? theme.primaryColor : theme.colorScheme.surfaceDim,
       centerTitle: true,
       actions: [
         if (currentRoute.path == Routes.campaigns.path)


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Use clean layout for 2fa if not logged in as navigating back and forth looks quite jumpy with the color change of the app bar.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Use a transparent/same color app bar if not logged in

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Navigate to 2fa from the login screen (logout if already logged in).

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

### Additional information

Old: 
https://wolke.netzbegruenung.de/s/JFEmd3we9sc9mrk

New:
https://wolke.netzbegruenung.de/s/99PHNMzEfNtb4jb





---