### PR TITLE
512: enforcing a keep-alive connection to avoid socket-errors

### DIFF
--- a/lib/app/services/gruene_api_core.dart
+++ b/lib/app/services/gruene_api_core.dart
@@ -10,7 +10,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 Future<GrueneApi> createGrueneApiClient() async {
   final userAgentHeaderValue = await _getUserAgentString();
-  List<chopper.Interceptor> interceptors = [UserAgentInterceptor(userAgentHeaderValue)];
+  List<chopper.Interceptor> interceptors = [UserAgentInterceptor(userAgentHeaderValue), ConnectionInterceptor()];
   chopper.Authenticator? authenticator;
 
   if (Config.grueneApiAccessToken.isNotEmpty) {
@@ -181,4 +181,18 @@ class AccessTokenAuthenticator implements chopper.Authenticator {
 
   @override
   chopper.AuthenticationCallback? get onAuthenticationSuccessful => null;
+}
+
+class ConnectionInterceptor implements chopper.Interceptor {
+  @override
+  FutureOr<chopper.Response<BodyType>> intercept<BodyType>(chopper.Chain<BodyType> chain) {
+    final updatedRequest = chopper.applyHeader(
+      chain.request,
+      HttpHeaders.connectionHeader,
+      'keep-alive',
+      override: false,
+    );
+
+    return chain.proceed(updatedRequest);
+  }
 }


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
This PR sets a "Connection: keep-alive" header for all request. We hope that prevents the error "Connection closed before full header was received"

### Proposed changes

<!-- Describe this PR in more detail. -->

-
-

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #512

---