### PR TITLE
504: configure secure storage globally

### DIFF
--- a/lib/app/auth/repository/auth_repository.dart
+++ b/lib/app/auth/repository/auth_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/constants/config.dart';
 import 'package:gruene_app/app/constants/secure_storage_keys.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
@@ -9,7 +10,7 @@ import 'package:logger/logger.dart';
 
 class AuthRepository {
   final FlutterAppAuth _appAuth = FlutterAppAuth();
-  final FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+  final _secureStorage = GetIt.instance<FlutterSecureStorage>();
   final Logger _logger = Logger();
 
   Future<bool> signIn() async {

--- a/lib/app/services/secure_storage_service.dart
+++ b/lib/app/services/secure_storage_service.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:get_it/get_it.dart';
+
+final getIt = GetIt.instance;
+
+void registerSecureStorage() {
+  getIt.registerSingleton<FlutterSecureStorage>(
+    const FlutterSecureStorage(
+      aOptions: AndroidOptions(
+        encryptedSharedPreferences: true,
+      ),
+    ),
+  );
+}

--- a/lib/features/mfa/domain/mfa_factory.dart
+++ b/lib/features/mfa/domain/mfa_factory.dart
@@ -1,15 +1,13 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:get_it/get_it.dart';
 import 'package:keycloak_authenticator/api.dart';
 
 class MfaFactory {
   static AuthenticatorService create() {
+    final secureStorage = GetIt.instance<FlutterSecureStorage>();
     return AuthenticatorService(
       storage: FlutterSecureStorageAdapter(
-        const FlutterSecureStorage(
-          aOptions: AndroidOptions(
-            encryptedSharedPreferences: true,
-          ),
-        ),
+        secureStorage,
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/auth/repository/auth_repository.dart';
 import 'package:gruene_app/app/router.dart';
 import 'package:gruene_app/app/services/gruene_api_core.dart';
+import 'package:gruene_app/app/services/secure_storage_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/app/widgets/clean_layout.dart';
 import 'package:gruene_app/features/campaigns/helper/campaign_session_settings.dart';
@@ -35,6 +36,7 @@ void main() async {
     await InAppWebViewController.setWebContentsDebuggingEnabled(kDebugMode);
   }
 
+  registerSecureStorage();
   GetIt.I.registerSingleton<GrueneApi>(await createGrueneApiClient());
   GetIt.I.registerSingleton<CampaignSessionSettings>(CampaignSessionSettings());
   GetIt.I.registerFactory<AuthenticatorService>(MfaFactory.create);


### PR DESCRIPTION
### Short description

Configure secure storage globally to avoid different configurations which lead to buggy behavior like overriding the storage.

### Proposed changes

- configure secure storage globally
- replace local instances with global secure storage instance

### Side effects

- Users need to login to the app again

### Testing

- navigate to the news page
- navigate to the mfa page
- navigate to the news page and check if news can still be loaded

### Resolved issues

Fixes: #504

---