### PR TITLE
542: get more details for the address if the only village identifier is present

### DIFF
--- a/lib/app/services/converters/place_parser.dart
+++ b/lib/app/services/converters/place_parser.dart
@@ -4,7 +4,7 @@ extension PlaceParser on Place {
   String getAddress() {
     var road = getRoad();
     var housenumber = getHouseNumber();
-    var city = getCity();
+    var city = getCityOrVillage();
     var zipCode = getZipCode();
     var state = getState();
     var municipality = getMunicipality();
@@ -46,8 +46,13 @@ extension PlaceParser on Place {
         '';
   }
 
+  String getCityOrVillage() {
+    var city = getCity();
+    return city.isEmpty ? (address?['village']?.toString() ?? '') : city;
+  }
+
   String getCity() {
-    return address?['city']?.toString() ?? address?['town']?.toString() ?? address?['village']?.toString() ?? '';
+    return address?['city']?.toString() ?? address?['town']?.toString() ?? '';
   }
 
   String getZipCode() {
@@ -72,5 +77,11 @@ extension PlaceParser on Place {
 
   String getCounty() {
     return address?['county']?.toString() ?? '';
+  }
+}
+
+extension AdressDetailParser on AddressDetail {
+  String? getCity() {
+    return addressTags?['city']?.toString();
   }
 }

--- a/lib/features/campaigns/screens/map_consumer.dart
+++ b/lib/features/campaigns/screens/map_consumer.dart
@@ -68,7 +68,7 @@ abstract class MapConsumer<T extends StatefulWidget> extends State<T> with Focus
       AppRoute<W?>(
         builder: (context) {
           return FutureBuilder(
-            future: locationAddress.timeout(const Duration(milliseconds: 800), onTimeout: () => AddressModel()),
+            future: locationAddress.timeout(const Duration(milliseconds: 1300), onTimeout: () => AddressModel()),
             builder: (context, AsyncSnapshot<AddressModel> snapshot) {
               if (!snapshot.hasData && !snapshot.hasError) {
                 return Container(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,13 +40,13 @@ void main() async {
   }
 
   registerSecureStorage();
-  GetIt.I.registerSingleton<GrueneApiCampaignsStatisticsService>(GrueneApiCampaignsStatisticsService());
   GetIt.I.registerSingleton<AppSettings>(AppSettings());
   GetIt.I.registerFactory<AuthenticatorService>(MfaFactory.create);
   GetIt.I.registerSingleton<IpService>(IpService());
   // Warning: The gruene api singleton depends on the auth repository which depends on the authenticator singleton
   // Therefore this should be last
   GetIt.I.registerSingleton<GrueneApi>(await createGrueneApiClient());
+  GetIt.I.registerSingleton<GrueneApiCampaignsStatisticsService>(GrueneApiCampaignsStatisticsService());
   GetIt.I.registerFactory<NominatimService>(() => NominatimService(countryCode: t.campaigns.search.country_code));
 
   runApp(TranslationProvider(child: const MyApp()));


### PR DESCRIPTION

### Short description

<!-- Describe this PR in one or two sentences. -->
One of the many edge cases where the OSM data is sometimes not so specific or misleading with the first request. A second request to gather details can reveal some more information

### Proposed changes

<!-- Describe this PR in more detail. -->

-
-

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-
-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #542 

---