### PR TITLE
557: Fix 2fa navigation

### DIFF
--- a/lib/app/constants/config.dart
+++ b/lib/app/constants/config.dart
@@ -20,6 +20,9 @@ class Config {
   static String get ipV4ServiceUrl => dotenv.env['IP_V4_SERVICE_URL']!;
   static String get ipV6ServiceUrl => dotenv.env['IP_V6_SERVICE_URL']!;
 
+  static String get defaultLocale => 'de_DE';
+  static String get defaultLanguageCode => 'de';
+
   static bool get androidFloss {
     // may be needed when building for f-droid store
     final configValue = dotenv.env['ANDROID_FLOSS'] ?? 'false';

--- a/lib/features/mfa/screens/token_scan_screen.dart
+++ b/lib/features/mfa/screens/token_scan_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/constants/config.dart';
 import 'package:gruene_app/app/constants/routes.dart';
 import 'package:gruene_app/app/theme/theme.dart';
@@ -48,7 +49,13 @@ class TokenScanScreen extends StatelessWidget {
         await Future<void>.delayed(const Duration(milliseconds: 100));
       }
       if (context.mounted) {
-        context.push(Routes.mfa.path);
+        while (context.canPop()) {
+          context.pop();
+        }
+        final bloc = context.read<AuthBloc>();
+        if (bloc.state is Unauthenticated) {
+          context.pushNamed(Routes.mfa.name!);
+        }
       }
     }
 
@@ -97,11 +104,7 @@ class TokenScanScreen extends StatelessWidget {
           const SizedBox(height: 16),
           Spacer(),
           TextButton(
-            onPressed: () => {
-              context.push(
-                '${Routes.mfa.path}/${Routes.mfaTokenInput.path}',
-              ),
-            },
+            onPressed: () => context.push('${Routes.mfa.path}/${Routes.mfaTokenInput.path}'),
             child: Text(
               t.mfa.tokenScan.doManual,
               style: theme.textTheme.bodyMedium!.apply(color: ThemeColors.text, decoration: TextDecoration.underline),

--- a/lib/features/mfa/widgets/last_granted_login_attempt_widget.dart
+++ b/lib/features/mfa/widgets/last_granted_login_attempt_widget.dart
@@ -51,7 +51,7 @@ class LastGrantedLoginAttemptWidget extends StatelessWidget {
                     style: theme.textTheme.bodyMedium,
                   ),
                   Text(
-                    '${state.lastGrantedLoginAttempt!.browser}, ${state.lastGrantedLoginAttempt!.os}',
+                    '${state.lastGrantedLoginAttempt!.browser}, ${state.lastGrantedLoginAttempt!.os} (${state.lastGrantedLoginAttempt!.ipAddress})',
                     style: theme.textTheme.bodyMedium,
                   ),
                   Text(

--- a/lib/features/mfa/widgets/verify_view.dart
+++ b/lib/features/mfa/widgets/verify_view.dart
@@ -90,7 +90,7 @@ class _VerifyViewState extends State<VerifyView> {
               textAlign: TextAlign.center,
             ),
             Text(
-              '${state.loginAttempt!.browser}, ${state.loginAttempt!.os}',
+              '${state.loginAttempt!.browser}, ${state.loginAttempt!.os} (${state.loginAttempt!.ipAddress})',
               style: theme.textTheme.bodyMedium,
               textAlign: TextAlign.center,
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/auth/repository/auth_repository.dart';
+import 'package:gruene_app/app/constants/config.dart';
 import 'package:gruene_app/app/router.dart';
 import 'package:gruene_app/app/services/gruene_api_campaigns_statistics_service.dart';
 import 'package:gruene_app/app/services/gruene_api_core.dart';
@@ -35,13 +36,7 @@ import 'package:timeago/timeago.dart' as timeago;
 Future<void> main() async {
   await dotenv.load(fileName: '.env');
   WidgetsFlutterBinding.ensureInitialized();
-  final locale = await LocaleSettings.useDeviceLocale();
-
-  if (locale.languageCode == 'de') {
-    timeago.setLocaleMessages('de', timeago.DeMessages());
-  } else {
-    timeago.setLocaleMessages('en', timeago.EnMessages());
-  }
+  timeago.setLocaleMessages(Config.defaultLanguageCode, timeago.DeMessages());
 
   if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
     await InAppWebViewController.setWebContentsDebuggingEnabled(kDebugMode);


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Fix back navigation after 2fa setup.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Pop all screens after successful setup (and push 2fa route again if not logged in)
- Show ip address of login attemps
- Only show 2fa timestamps in German to keep language consistent

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Setup 2fa both while logged in/logged out and navigate back

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #557

---