### PR TITLE
Add Format Settings for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,10 @@
     "circleci.persistedProjectSelection": [
         "gh/verdigado/gruene-app"
     ],
-    "cSpell.enabled": false
+    "cSpell.enabled": false,
+    "dart.lineLength": 120,
+    "[dart]": {
+        "editor.formatOnSave": true,
+        "editor.rulers": [120],
+    }
 }


### PR DESCRIPTION
### Short description

* add VSCode settings to use the same formatting style as checked by the linter in the build pipelines