### PR TITLE
595: Make image full width and only use necessary space

### DIFF
--- a/lib/features/news/screens/news_detail_screen.dart
+++ b/lib/features/news/screens/news_detail_screen.dart
@@ -31,48 +31,45 @@ class NewsDetailScreen extends StatelessWidget {
           child: Stack(
             children: [
               Positioned.fill(
-                child: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      SizedBox(
-                        height: 288,
-                        child: featuredImage(news),
+                child: ListView(
+                  children: [
+                    SizedBox(
+                      width: double.infinity,
+                      child: FullWidthImage(news: news),
+                    ),
+                    Container(
+                      padding: EdgeInsets.all(20),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          author != null ? Text(t.news.writtenBy(author: author)) : Container(),
+                          Text(
+                            news.title,
+                            style: theme.textTheme.titleLarge,
+                          ),
+                          SizedBox(height: 16),
+                          Text(
+                            t.news.updatedAt(date: formatDate(news.createdAt)),
+                            style: theme.textTheme.labelSmall,
+                          ),
+                          Text(
+                            news.summary,
+                            style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
+                          ),
+                          SizedBox(height: 24),
+                          Html(
+                            data: news.content,
+                            onLinkTap: (url, _, __) => url != null ? openUrl(url, context) : null,
+                            style: {
+                              'body': Style(
+                                margin: Margins.zero,
+                              ),
+                            },
+                          ),
+                        ],
                       ),
-                      Container(
-                        padding: EdgeInsets.all(20),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            author != null ? Text(t.news.writtenBy(author: author)) : Container(),
-                            Text(
-                              news.title,
-                              style: theme.textTheme.titleLarge,
-                            ),
-                            SizedBox(height: 16),
-                            Text(
-                              t.news.updatedAt(date: formatDate(news.createdAt)),
-                              style: theme.textTheme.labelSmall,
-                            ),
-                            Text(
-                              news.summary,
-                              style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
-                            ),
-                            SizedBox(height: 24),
-                            Html(
-                              data: news.content,
-                              onLinkTap: (url, _, __) => url != null ? openUrl(url, context) : null,
-                              style: {
-                                'body': Style(
-                                  margin: Margins.zero,
-                                ),
-                              },
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
               // Positioned(
@@ -93,13 +90,26 @@ class NewsDetailScreen extends StatelessWidget {
       },
     );
   }
+}
 
-  Widget featuredImage(NewsModel news) {
-    if (news.image != null) {
-      return CachedNetworkImage(
-        imageUrl: selectImageVariant(news.image!, 'wide'),
-      );
+class FullWidthImage extends StatelessWidget {
+  final NewsModel news;
+
+  const FullWidthImage({super.key, required this.news});
+
+  @override
+  Widget build(BuildContext context) {
+    final image = news.image;
+    if (image == null) {
+      return Image.asset(getPlaceholderImage(news.id));
     }
-    return Image.asset(getPlaceholderImage(news.id));
+
+    final imageVariant = image.variant('wide');
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    final imageHeight = imageVariant.height * screenWidth / imageVariant.width;
+    return CachedNetworkImage(
+      placeholder: (_, __) => SizedBox(height: imageHeight),
+      imageUrl: imageVariant.url,
+    );
   }
 }

--- a/lib/features/news/utils/utils.dart
+++ b/lib/features/news/utils/utils.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Image;
+import 'package:gruene_app/app/utils/utils.dart';
 import 'package:gruene_app/features/news/models/news_model.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
@@ -25,11 +26,6 @@ String getPlaceholderImage(String id) {
   return 'assets/graphics/placeholders/placeholder_${int.parse(id) % 3 + 1}.jpg';
 }
 
-String selectImageVariant(ImageSrcSet image, String type) {
-  for (var variant in image.srcset) {
-    if (variant.type == type) {
-      return variant.url;
-    }
-  }
-  return image.original.url;
+extension ImageVariant on ImageSrcSet {
+  Image variant(String type) => srcset.firstWhereOrNull((image) => image.type == type) ?? original;
 }

--- a/lib/features/news/widgets/news_card.dart
+++ b/lib/features/news/widgets/news_card.dart
@@ -136,9 +136,10 @@ class NewsCard extends StatelessWidget {
   }
 
   DecorationImage featuredImage(NewsModel news) {
+    final image = news.image;
     return DecorationImage(
-      image: news.image != null
-          ? CachedNetworkImageProvider(selectImageVariant(news.image!, 'large'))
+      image: image != null
+          ? CachedNetworkImageProvider(image.variant('large').url)
           : AssetImage(getPlaceholderImage(news.id)),
       fit: BoxFit.fitWidth,
     );


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Make image full width and only use necessary space.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Make images span the whole width and only occupy needed height
- Replace SingleChildScrollView and Column with ListView

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Images might now occupy more than the previously set height depending on the aspect ratio
- There is still a faint white line between the app bar and the image. I was not able to figure out the reason. Perhaps you have any idea?

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to news details.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #595

### Additional Information

<img width="200px" src="https://github.com/user-attachments/assets/87287944-97d4-43d4-b7d7-f0d16bd3b121" />
<img width="200px" src="https://github.com/user-attachments/assets/29607a2a-fb81-4048-b897-c00375c1c01d" />
<img width="200px" src="https://github.com/user-attachments/assets/35c4822b-faf7-4954-8ff8-d80b958623a3" />

---