### PR TITLE
607: Align design of accordions in news details

### DIFF
--- a/lib/app/widgets/expansion_list_tile.dart
+++ b/lib/app/widgets/expansion_list_tile.dart
@@ -1,24 +1,34 @@
 import 'package:flutter/material.dart';
+import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/app/utils/utils.dart';
 
 class ExpansionListTile extends StatelessWidget {
   final List<Widget> children;
   final String title;
+  final EdgeInsetsGeometry titlePadding;
+  final Color? backgroundColor;
 
-  const ExpansionListTile({super.key, required this.children, required this.title});
+  const ExpansionListTile({
+    super.key,
+    required this.children,
+    required this.title,
+    this.titlePadding = const EdgeInsets.symmetric(horizontal: 24),
+    this.backgroundColor,
+  });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 24),
       color: theme.colorScheme.surface,
       child: ExpansionTile(
         shape: const Border(),
         title: Text(title),
-        tilePadding: const EdgeInsets.all(0),
-        backgroundColor: theme.colorScheme.surface,
-        collapsedBackgroundColor: theme.colorScheme.surface,
+        tilePadding: titlePadding,
+        backgroundColor: backgroundColor ?? theme.colorScheme.surface,
+        collapsedBackgroundColor: backgroundColor ?? theme.colorScheme.surface,
+        iconColor: ThemeColors.textDisabled,
+        collapsedIconColor: ThemeColors.textDisabled,
         children: children.withDividers(),
       ),
     );

--- a/lib/app/widgets/html.dart
+++ b/lib/app/widgets/html.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/app/utils/open_url.dart';
+import 'package:gruene_app/app/utils/utils.dart';
+import 'package:gruene_app/app/widgets/expansion_list_tile.dart';
+
+final TagExtension accordionTagExtension = TagExtension(
+  tagsToExtend: {'dl'},
+  builder: (extensionContext) {
+    final theme = Theme.of(extensionContext.buildContext!);
+    final children = extensionContext.elementChildren;
+    final title = children.firstWhereOrNull((child) => child.localName == 'dt');
+    final innerHtml = children.firstWhereOrNull((child) => child.localName == 'dd')?.innerHtml;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: ExpansionListTile(
+        title: title?.text ?? '',
+        backgroundColor: ThemeColors.textLight,
+        titlePadding: const EdgeInsets.symmetric(horizontal: 8),
+        children: innerHtml != null
+            ? [
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  decoration: BoxDecoration(
+                    border: Border.all(color: ThemeColors.textLight),
+                    color: theme.colorScheme.surface,
+                  ),
+                  child: CustomHtml(data: innerHtml),
+                ),
+              ]
+            : [],
+      ),
+    );
+  },
+);
+
+class CustomHtml extends StatelessWidget {
+  final String data;
+
+  const CustomHtml({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    return Html(
+      data: data,
+      extensions: [accordionTagExtension],
+      onLinkTap: (url, _, __) => url != null ? openUrl(url, context) : null,
+      style: {
+        'body': Style(margin: Margins.zero),
+      },
+    );
+  }
+}

--- a/lib/features/news/screens/news_detail_screen.dart
+++ b/lib/features/news/screens/news_detail_screen.dart
@@ -1,10 +1,9 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_html/flutter_html.dart';
 import 'package:gruene_app/app/screens/error_screen.dart';
 import 'package:gruene_app/app/screens/future_loading_screen.dart';
 import 'package:gruene_app/app/utils/format_date.dart';
-import 'package:gruene_app/app/utils/open_url.dart';
+import 'package:gruene_app/app/widgets/html.dart';
 import 'package:gruene_app/features/news/domain/news_api_service.dart';
 import 'package:gruene_app/features/news/models/news_model.dart';
 import 'package:gruene_app/features/news/utils/utils.dart';
@@ -57,15 +56,7 @@ class NewsDetailScreen extends StatelessWidget {
                             style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
                           ),
                           SizedBox(height: 24),
-                          Html(
-                            data: news.content,
-                            onLinkTap: (url, _, __) => url != null ? openUrl(url, context) : null,
-                            style: {
-                              'body': Style(
-                                margin: Margins.zero,
-                              ),
-                            },
-                          ),
+                          CustomHtml(data: news.content),
                         ],
                       ),
                     ),


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Adjust rendering of accordions in news details to align with the Grünes Netz.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Extract html widget
- Use a TagExtension to render `dl`, `dd`, `dt`
- Fix minor design issues of the news filter related to the accordion division filter (press target, icon color)
- Make ExpansionListTile more configurable

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check https://netz.gruene.de/de/aktuelles/2025-02/robert-im-tv.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #607 

### Additional Information
<img src="https://github.com/user-attachments/assets/951357f7-23a0-4315-9d83-93998679548c" width="300px" />


---