### PR TITLE
214: Show division in news detail

### DIFF
--- a/lib/app/utils/divisions.dart
+++ b/lib/app/utils/divisions.dart
@@ -1,7 +1,7 @@
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
 extension DivisionExtension on Division {
-  String shortDisplayName() => level == DivisionLevel.bv ? name2 : shortName;
+  String shortDisplayName() => level == DivisionLevel.bv ? name2 : '${level.value} $name2';
 }
 
 extension DivisionFilter on Iterable<Division> {

--- a/lib/features/news/models/news_model.dart
+++ b/lib/features/news/models/news_model.dart
@@ -7,7 +7,6 @@ class NewsModel {
   String title;
   String summary;
   String content;
-  String? author;
   ImageSrcSet? image;
   String type;
   Division? division;
@@ -20,7 +19,6 @@ class NewsModel {
     required this.title,
     required this.summary,
     required this.content,
-    required this.author,
     required this.image,
     required this.type,
     required this.division,
@@ -36,7 +34,6 @@ class NewsModel {
       title: news.title,
       summary: news.summary ?? 'Leere Zusammenfassung.',
       content: news.body.content,
-      author: null,
       image: news.featuredImage,
       type: news.categories.firstOrNull?.label ?? '',
       division: division,

--- a/lib/features/news/screens/news_detail_screen.dart
+++ b/lib/features/news/screens/news_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:gruene_app/app/screens/error_screen.dart';
 import 'package:gruene_app/app/screens/future_loading_screen.dart';
+import 'package:gruene_app/app/utils/divisions.dart';
 import 'package:gruene_app/app/utils/format_date.dart';
 import 'package:gruene_app/app/utils/open_url.dart';
 import 'package:gruene_app/features/news/domain/news_api_service.dart';
@@ -24,7 +25,7 @@ class NewsDetailScreen extends StatelessWidget {
         if (news == null) {
           return ErrorScreen(error: t.news.newsNotFound, retry: () => fetchNewsById(newsId));
         }
-        final author = news.author;
+        final division = news.division;
         return SizedBox(
           width: double.infinity,
           height: double.infinity,
@@ -42,7 +43,7 @@ class NewsDetailScreen extends StatelessWidget {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          author != null ? Text(t.news.writtenBy(author: author)) : Container(),
+                          division != null ? Text(division.shortDisplayName()) : Container(),
                           Text(
                             news.title,
                             style: theme.textTheme.titleLarge?.apply(fontFamily: 'GrueneType'),


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Show division in news detail.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Show division in news detail
- Remove author related code

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- @NikoHadouken [raised the question](https://github.com/verdigado/gruene-app/pull/586#discussion_r1946764816) whether it is a good idea to manually put together the division name as `name properties of divisions are not used consistent`. However, to align the naming to the Grünes Netz (`LV Bremen`, `KV Braunschweig`), this is necessary. The alternative would be to use the `shortName` property and display e.g. `Bremen LV` or `Braunschweig KV`. @iantrieschmann @JuliaFreitagBGSt what do you think?
- @iantrieschmann @JuliaFreitagBGSt @leagerndt I tried to align it to the figma design, i.e. not using a chip for displaying the division. If you want me to use a chip (see *Chip Alternative* below), let me know. Personally, I think this looks and fits better compared to the chip alternative.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to news detail and check the division.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #214

### Additional Information

#### Implemented Version (aligning with figma design):

<img src="https://github.com/user-attachments/assets/eb36edde-f196-44ad-9805-e22cd274a1bc" width="300px" />
<img src="https://github.com/user-attachments/assets/d12913b9-7112-4eb8-b273-bbeba2730dbe" width="300px" />

#### Chip Alternative (aligning with Grünes Netz):

<img src="https://github.com/user-attachments/assets/a4953f08-eeec-4920-85b9-b982db3f6b5f" width="300px" />

---