### PR TITLE
610: quick action for poster to mark as "removed"

### DIFF
--- a/lib/app/services/converters/poster_detail_model_extension.dart
+++ b/lib/app/services/converters/poster_detail_model_extension.dart
@@ -6,6 +6,19 @@ extension PosterDetailModelExtension on PosterDetailModel {
     photos.sortByIdDescending();
     return photos.first;
   }
+
+  PosterUpdateModel asPosterUpdate() {
+    return PosterUpdateModel(
+      id: id,
+      address: address,
+      status: status,
+      comment: comment,
+      location: location,
+      oldPosterDetail: this,
+      deletedPhotoIds: [],
+      newPhotos: [],
+    );
+  }
 }
 
 extension PosterPhotoModelListExtension on List<PosterPhotoModel> {

--- a/lib/features/campaigns/screens/poster_edit.dart
+++ b/lib/features/campaigns/screens/poster_edit.dart
@@ -351,16 +351,14 @@ class _PosterEditState extends State<PosterEdit> with AddressExtension, ConfirmD
       newPhotosReduced.add(newPhoto);
     }
 
-    final updateModel = PosterUpdateModel(
-      id: widget.poster.id,
-      address: getAddress(),
-      status: _selectedPosterStatus,
-      comment: commentTextController.text,
-      location: widget.poster.location,
-      deletedPhotoIds: _deletedPhotoIds,
-      newPhotos: newPhotosReduced,
-      oldPosterDetail: widget.poster,
-    );
+    final updateModel = widget.poster.asPosterUpdate().copyWith(
+          address: getAddress(),
+          status: _selectedPosterStatus,
+          comment: commentTextController.text,
+          location: widget.poster.location,
+          deletedPhotoIds: _deletedPhotoIds,
+          newPhotos: newPhotosReduced,
+        );
     await widget.onSave(updateModel);
 
     _closeDialog(ModalEditResult.save);

--- a/lib/features/campaigns/screens/posters_screen.dart
+++ b/lib/features/campaigns/screens/posters_screen.dart
@@ -187,6 +187,7 @@ class _PostersScreenState extends MapConsumer<PostersScreen, PosterCreateModel, 
     getPoiDetailWidget(PosterDetailModel poster) {
       return PosterDetail(
         poi: poster,
+        onSave: savePoi,
       );
     }
 

--- a/lib/i18n/app_de.json
+++ b/lib/i18n/app_de.json
@@ -11,6 +11,7 @@
       "cancel": "Abbrechen",
       "delete": "Löschen",
       "edit": "Bearbeiten",
+      "undo": "Rückgängig",
       "consent": "Verstanden",
       "settings": "Einstellungen",
       "openSettings": "Einstellungen öffnen",
@@ -94,7 +95,9 @@
         },
         "removed": {
           "label": "Abgehängt",
-          "description": "Plakat wurde abgehängt."
+          "description": "Plakat wurde abgehängt.",
+          "quick_action_label": "Plakat abgehängt",
+          "quick_action_result": "Als abgehängt markiert"
         },
         "to_be_moved": {
           "label": "Umzuhängen",


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
- introduce a quick action on poster detail to remove poster
- allow undo
- not show "remove poster" when currently in state "REMOVED"

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #610

---