### PR TITLE
618: remove summary from news detail screen

### DIFF
--- a/lib/features/news/screens/news_detail_screen.dart
+++ b/lib/features/news/screens/news_detail_screen.dart
@@ -52,11 +52,6 @@ class NewsDetailScreen extends StatelessWidget {
                             t.news.updatedAt(date: formatDate(news.createdAt)),
                             style: theme.textTheme.labelSmall,
                           ),
-                          Text(
-                            news.summary,
-                            style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
-                          ),
-                          SizedBox(height: 24),
                           CustomHtml(data: news.content),
                         ],
                       ),


### PR DESCRIPTION
### Short Description

Removes the summary from news detail screen.

### Proposed Changes

- Summary is no longer visible below entry createdAt date and above content.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
None.

### Testing

Navigate to a news detail. The news entry from the issue (#618) with the title "Endspurt: Telefonaktion" is a good test case.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #618 

---