### PR TITLE
499: enable edge-to-edge mode and add safe area around content where …

### DIFF
--- a/lib/app/widgets/clean_layout.dart
+++ b/lib/app/widgets/clean_layout.dart
@@ -11,7 +11,7 @@ class CleanLayout extends StatelessWidget {
     final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(backgroundColor: theme.colorScheme.surface, toolbarHeight: showAppBar ? null : 0),
-      body: Container(color: theme.colorScheme.surface, child: child),
+      body: SafeArea(child: Container(color: theme.colorScheme.surface, child: child)),
     );
   }
 }

--- a/lib/app/widgets/main_layout.dart
+++ b/lib/app/widgets/main_layout.dart
@@ -11,8 +11,8 @@ class MainLayout extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: child,
-      bottomNavigationBar: const BottomNavigation(),
+      body: SafeArea(child: child),
+      bottomNavigationBar: SafeArea(child: const BottomNavigation()),
       appBar: appBar ?? MainAppBar(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
@@ -38,6 +39,7 @@ import 'package:timeago/timeago.dart' as timeago;
 Future<void> main() async {
   await dotenv.load(fileName: '.env');
   WidgetsFlutterBinding.ensureInitialized();
+  SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
   final locale = await LocaleSettings.useDeviceLocale();
   Intl.defaultLocale = locale.underscoreTag;
   await initializeDateFormatting();


### PR DESCRIPTION
### Short Description

Enable edge-to-edge mode.

### Proposed Changes

- Edge to edge view on supported devices.
- No warnings in google play console about missing implementation anymore.

### Side Effects

None.

### Testing

- Navigate through the app and check layout, especially spacing on top and bottom of the screen.
- Also check screens not showing top and/or bottom navigation bar.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #499

---