### PR TITLE
603: Show meaningful errors and hide errors during periodic mfa refreshes

### DIFF
--- a/lib/app/screens/error_screen.dart
+++ b/lib/app/screens/error_screen.dart
@@ -4,14 +4,12 @@ import 'package:gruene_app/app/utils/error_message.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 
 class ErrorScreen<T> extends StatelessWidget {
-  final Object error;
+  final Object? error;
+  final String? errorMessage;
   final T Function() retry;
 
-  const ErrorScreen({
-    super.key,
-    required this.error,
-    required this.retry,
-  });
+  const ErrorScreen({super.key, required this.retry, this.error, this.errorMessage})
+      : assert((error == null) != (errorMessage == null));
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +18,7 @@ class ErrorScreen<T> extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Text(
-            getErrorMessage(error),
+            errorMessage ?? getErrorMessage(error!),
             textAlign: TextAlign.center,
             style: TextStyle(color: ThemeColors.textWarning),
           ),

--- a/lib/app/screens/error_screen.dart
+++ b/lib/app/screens/error_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/app/utils/error_message.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 
 class ErrorScreen<T> extends StatelessWidget {
-  final String error;
+  final Object error;
   final T Function() retry;
 
   const ErrorScreen({
@@ -14,14 +15,12 @@ class ErrorScreen<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final message =
-        error.startsWith('ClientException') ? t.error.offlineError : error.substring(error.indexOf(':') + 1);
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Text(
-            message,
+            getErrorMessage(error),
             textAlign: TextAlign.center,
             style: TextStyle(color: ThemeColors.textWarning),
           ),

--- a/lib/app/screens/error_screen.dart
+++ b/lib/app/screens/error_screen.dart
@@ -9,7 +9,7 @@ class ErrorScreen<T> extends StatelessWidget {
   final T Function() retry;
 
   const ErrorScreen({super.key, required this.retry, this.error, this.errorMessage})
-      : assert((error == null) != (errorMessage == null));
+      : assert((error == null) != (errorMessage == null) && error is! String);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/screens/future_loading_screen.dart
+++ b/lib/app/screens/future_loading_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:gruene_app/app/screens/error_screen.dart';
-import 'package:gruene_app/i18n/translations.g.dart';
 
 class FutureLoadingScreen<T> extends StatefulWidget {
   final Future<T> Function() load;

--- a/lib/app/screens/future_loading_screen.dart
+++ b/lib/app/screens/future_loading_screen.dart
@@ -45,7 +45,7 @@ class _FutureLoadingScreenState<T> extends State<FutureLoadingScreen<T>> {
         if (snapshot.hasError || !snapshot.hasData || data == null) {
           return layoutBuilder(
             ErrorScreen(
-              error: snapshot.error?.toString() ?? t.error.unknownError,
+              error: snapshot.error ?? Exception(),
               retry: () {
                 setState(() {});
                 _data = widget.load();

--- a/lib/app/utils/error_message.dart
+++ b/lib/app/utils/error_message.dart
@@ -1,0 +1,8 @@
+import 'package:gruene_app/i18n/translations.g.dart';
+
+String getErrorMessage(Object error, {String? defaultMessage}) {
+  if (error.toString().contains('Failed host lookup')) {
+    return t.error.offlineError;
+  }
+  return defaultMessage ?? t.error.unknownError;
+}

--- a/lib/app/utils/show_snack_bar.dart
+++ b/lib/app/utils/show_snack_bar.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+void showSnackBar(BuildContext context, String text) {
+  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(text)));
+}

--- a/lib/features/mfa/bloc/mfa_bloc.dart
+++ b/lib/features/mfa/bloc/mfa_bloc.dart
@@ -51,13 +51,8 @@ class MfaBloc extends Bloc<MfaEvent, MfaState> {
           loginAttempt: null,
         ),
       );
-    } catch (err) {
-      emit(
-        state.copyWith(
-          error: err.toString(),
-          isLoading: false,
-        ),
-      );
+    } catch (error) {
+      emit(state.copyWith(error: error, isLoading: false));
     }
   }
 
@@ -72,8 +67,8 @@ class MfaBloc extends Bloc<MfaEvent, MfaState> {
           lastRefresh: null,
         ),
       );
-    } catch (err) {
-      emit(state.copyWith(error: err.toString()));
+    } catch (error) {
+      emit(state.copyWith(error: error));
     }
   }
 
@@ -107,29 +102,17 @@ class MfaBloc extends Bloc<MfaEvent, MfaState> {
           ),
         );
       }
-    } on KeycloakClientException catch (err) {
-      if (err.type == KeycloakExceptionType.notRegistered) {
+    } on KeycloakClientException catch (error) {
+      if (error.type == KeycloakExceptionType.notRegistered) {
         try {
           await _service.delete(_authenticator!);
           _authenticator = null;
           emit(state.copyWith(status: MfaStatus.setup));
         } catch (_) {}
       }
-      emit(
-        state.copyWith(
-          error: err.toString(),
-          loginAttempt: null,
-          isLoading: false,
-        ),
-      );
-    } catch (err) {
-      emit(
-        state.copyWith(
-          error: err.toString(),
-          loginAttempt: null,
-          isLoading: false,
-        ),
-      );
+      emit(state.copyWith(error: event.raiseError ? error : null, loginAttempt: null, isLoading: false));
+    } catch (error) {
+      emit(state.copyWith(error: event.raiseError ? error : null, loginAttempt: null, isLoading: false));
     }
   }
 
@@ -149,14 +132,8 @@ class MfaBloc extends Bloc<MfaEvent, MfaState> {
           lastGrantedLoginAttempt: event.granted ? state.loginAttempt : null,
         ),
       );
-    } catch (err) {
-      emit(
-        state.copyWith(
-          status: MfaStatus.ready,
-          error: err.toString(),
-          isLoading: false,
-        ),
-      );
+    } catch (error) {
+      emit(state.copyWith(status: MfaStatus.ready, error: error, isLoading: false));
     }
   }
 

--- a/lib/features/mfa/bloc/mfa_bloc.dart
+++ b/lib/features/mfa/bloc/mfa_bloc.dart
@@ -29,10 +29,10 @@ class MfaBloc extends Bloc<MfaEvent, MfaState> {
           loginAttempt: null,
         ),
       );
-    } catch (err) {
+    } catch (error) {
       emit(
         state.copyWith(
-          error: err.toString(),
+          error: error,
           loginAttempt: null,
         ),
       );

--- a/lib/features/mfa/bloc/mfa_event.dart
+++ b/lib/features/mfa/bloc/mfa_event.dart
@@ -20,7 +20,11 @@ class SetupMfa extends MfaEvent {
 
 class DeleteMfa extends MfaEvent {}
 
-class RefreshMfa extends MfaEvent {}
+class RefreshMfa extends MfaEvent {
+  final bool raiseError;
+
+  const RefreshMfa({this.raiseError = true});
+}
 
 class SendReply extends MfaEvent {
   final bool granted;

--- a/lib/features/mfa/bloc/mfa_state.dart
+++ b/lib/features/mfa/bloc/mfa_state.dart
@@ -5,7 +5,7 @@ enum MfaStatus { init, setup, ready, verify }
 
 class MfaState extends Equatable {
   final MfaStatus status;
-  final String? error;
+  final Object? error;
   final bool isLoading;
   final LoginAttemptDto? loginAttempt;
   final DateTime? lastRefresh;
@@ -22,7 +22,7 @@ class MfaState extends Equatable {
 
   MfaState copyWith({
     MfaStatus? status,
-    String? error,
+    Object? error,
     bool? isLoading,
     LoginAttemptDto? loginAttempt,
     DateTime? lastRefresh,

--- a/lib/features/mfa/screens/mfa_screen.dart
+++ b/lib/features/mfa/screens/mfa_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gruene_app/app/utils/error_message.dart';
+import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_bloc.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_event.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_state.dart';
@@ -14,12 +16,9 @@ class MfaScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocConsumer<MfaBloc, MfaState>(
       listener: (context, state) {
-        if (state.error != null) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(state.error!),
-            ),
-          );
+        final error = state.error;
+        if (error != null) {
+          showSnackBar(context, getErrorMessage(error));
         }
       },
       builder: (context, state) {

--- a/lib/features/mfa/screens/token_input_screen.dart
+++ b/lib/features/mfa/screens/token_input_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:gruene_app/app/constants/routes.dart';
+import 'package:gruene_app/app/utils/error_message.dart';
+import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_bloc.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_event.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_state.dart';
@@ -27,12 +29,9 @@ class _TokenInputScreenState extends State<TokenInputScreen> {
 
     if (!context.mounted) return;
 
-    if (bloc.state.error != null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(bloc.state.error.toString()),
-        ),
-      );
+    final error = bloc.state.error;
+    if (error != null) {
+      showSnackBar(context, getErrorMessage(error));
     }
 
     Future<void> waitForReadyStatus() async {

--- a/lib/features/mfa/screens/token_scan_screen.dart
+++ b/lib/features/mfa/screens/token_scan_screen.dart
@@ -5,6 +5,8 @@ import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/constants/config.dart';
 import 'package:gruene_app/app/constants/routes.dart';
 import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/app/utils/error_message.dart';
+import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_bloc.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_event.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_state.dart';
@@ -19,11 +21,7 @@ class TokenScanScreen extends StatelessWidget {
 
     // prevent authenticator registration with arbitrary keycloak instances
     if (!value.startsWith(Config.oidcIssuer)) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(t.mfa.tokenScan.oidcIssuerMissmatch),
-        ),
-      );
+      showSnackBar(context, t.mfa.tokenScan.oidcIssuerMissmatch);
       return;
     }
 
@@ -35,12 +33,9 @@ class TokenScanScreen extends StatelessWidget {
 
     if (!context.mounted) return;
 
-    if (bloc.state.error != null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(bloc.state.error.toString()),
-        ),
-      );
+    final error = bloc.state.error;
+    if (error != null) {
+      showSnackBar(context, getErrorMessage(error));
       return;
     }
 

--- a/lib/features/mfa/widgets/ready_view.dart
+++ b/lib/features/mfa/widgets/ready_view.dart
@@ -31,7 +31,7 @@ class _ReadyViewState extends State<ReadyView> {
 
   void _startPeriodicRefresh() {
     _timer = Timer.periodic(Duration(seconds: 5), (timer) {
-      context.read<MfaBloc>().add(RefreshMfa());
+      context.read<MfaBloc>().add(RefreshMfa(raiseError: false));
     });
   }
 

--- a/lib/features/news/screens/news_detail_screen.dart
+++ b/lib/features/news/screens/news_detail_screen.dart
@@ -22,7 +22,7 @@ class NewsDetailScreen extends StatelessWidget {
       load: () => fetchNewsById(newsId),
       buildChild: (NewsModel? news) {
         if (news == null) {
-          return ErrorScreen(error: t.news.newsNotFound, retry: () => fetchNewsById(newsId));
+          return ErrorScreen(errorMessage: t.news.newsNotFound, retry: () => fetchNewsById(newsId));
         }
         final division = news.division;
         return SizedBox(

--- a/lib/features/news/widgets/news_list.dart
+++ b/lib/features/news/widgets/news_list.dart
@@ -32,7 +32,7 @@ class NewsList extends StatelessWidget {
       buildChild: (List<NewsModel> data) {
         final news = data.filter(selectedDivisions, selectedCategories, showBookmarked, dateRange);
         if (news.isEmpty) {
-          return ErrorScreen(error: t.news.noResults, retry: fetchNews);
+          return ErrorScreen(errorMessage: t.news.noResults, retry: fetchNews);
         }
         return ListView.builder(
           itemCount: news.length,

--- a/lib/features/profiles/screens/own_profile_screen.dart
+++ b/lib/features/profiles/screens/own_profile_screen.dart
@@ -20,7 +20,7 @@ class OwnProfileScreen extends StatelessWidget {
       load: fetchOwnProfile,
       buildChild: (Profile? data) {
         if (data == null) {
-          return ErrorScreen(error: t.profiles.noResult, retry: fetchOwnProfile);
+          return ErrorScreen(errorMessage: t.profiles.noResult, retry: fetchOwnProfile);
         }
 
         Iterable<ProfileRole> mandateRoles =


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Show meaningful error messages and hide errors during periodic mfa refreshes.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Show meaningful messages for mfa errors
- Hide errors happening during automatic polling
- Make ErrorScreen accept raw errors and error messages
- Extract showSnackBar and getErrorMessage

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Users are not notified of being offline after initially visiting the mfa screen.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
1. Open the app
2. Turn off the internet connection
3. Navigate to mfa screen
4. See a snackbar about being offline shown initially
5. See NO further snackbar
6. Hit `Aktualisieren` and see another snackbar
7. Navigate to maps and see NO snackbar (compare to current store version and screenshot in #603). 

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #603

---