### PR TITLE
63: add digital membership card

### DIFF
--- a/lib/app/constants/routes.dart
+++ b/lib/app/constants/routes.dart
@@ -9,6 +9,7 @@ import 'package:gruene_app/features/mfa/screens/token_input_screen.dart';
 import 'package:gruene_app/features/mfa/screens/token_scan_screen.dart';
 import 'package:gruene_app/features/news/screens/news_detail_screen.dart';
 import 'package:gruene_app/features/news/screens/news_screen.dart';
+import 'package:gruene_app/features/profiles/screens/digital_membership_card_screen.dart';
 import 'package:gruene_app/features/profiles/screens/own_profile_screen.dart';
 import 'package:gruene_app/features/settings/screens/settings_screen.dart';
 import 'package:gruene_app/features/settings/screens/support_screen.dart';
@@ -41,7 +42,10 @@ class Routes {
   static GoRoute news =
       buildRoute('/news', t.news.news, NewsScreenContainer(), routes: [newsDetail], withMainLayout: false);
   static GoRoute campaigns = buildRoute('/campaigns', t.campaigns.campaigns, CampaignsScreen());
-  static GoRoute profiles = buildRoute('/profiles', t.profiles.profiles, OwnProfileScreen());
+  static GoRoute digitalMembershipCard =
+      buildRoute('digital-membership-card', t.profiles.digitalMembershipCard.title, DigitalMembershipCardScreen());
+  static GoRoute profiles =
+      buildRoute('/profiles', t.profiles.profiles, OwnProfileScreen(), routes: [digitalMembershipCard]);
   static GoRoute mfaTokenScan = buildRoute('token-scan', t.mfa.tokenScan.title, TokenScanScreen());
   static GoRoute mfaTokenInput = buildRoute('token-input', t.mfa.tokenInput.title, TokenInputScreen());
   static GoRoute mfa = buildRoute('/mfa', t.mfa.mfa, MfaScreen(), routes: [mfaTokenScan, mfaTokenInput]);

--- a/lib/app/theme/theme.dart
+++ b/lib/app/theme/theme.dart
@@ -51,6 +51,15 @@ class _ThemeTextStyles {
   );
   static TextStyle displayLarge = displayMedium.copyWith(fontSize: 34, height: 1.2, letterSpacing: 0.03);
 
+  static TextStyle headlineLarge = GoogleFonts.ptSans(
+    textStyle: TextStyle(
+      fontSize: 42,
+      fontWeight: FontWeight.w700,
+      height: 1.02,
+      letterSpacing: 0.02,
+    ),
+  );
+
   static TextStyle titleMedium = GoogleFonts.ptSans(
     textStyle: TextStyle(
       fontSize: 18,
@@ -144,6 +153,7 @@ final ThemeData appTheme = ThemeData.light().copyWith(
   textTheme: TextTheme(
     displayLarge: _ThemeTextStyles.displayLarge,
     displayMedium: _ThemeTextStyles.displayMedium,
+    headlineLarge: _ThemeTextStyles.headlineLarge,
     titleLarge: _ThemeTextStyles.titleLarge,
     titleMedium: _ThemeTextStyles.titleMedium,
     titleSmall: _ThemeTextStyles.titleSmall,

--- a/lib/features/profiles/screens/digital_membership_card_screen.dart
+++ b/lib/features/profiles/screens/digital_membership_card_screen.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:gruene_app/app/screens/error_screen.dart';
+import 'package:gruene_app/app/screens/future_loading_screen.dart';
+import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/app/widgets/icon.dart';
+import 'package:gruene_app/features/profiles/domain/profiles_api_service.dart';
+import 'package:gruene_app/i18n/translations.g.dart';
+import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+class DigitalMembershipCardScreen extends StatelessWidget {
+  const DigitalMembershipCardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return FutureLoadingScreen(
+      load: fetchOwnProfile,
+      buildChild: (Profile? data) {
+        if (data == null) {
+          return ErrorScreen(error: t.profiles.noResult, retry: fetchOwnProfile);
+        }
+
+        DivisionMembership? kvMembership =
+            data.memberships?.where((membership) => membership.division.level == DivisionLevel.kv).firstOrNull;
+
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Container(
+            padding: const EdgeInsets.fromLTRB(20, 24, 12, 12),
+            decoration: BoxDecoration(
+              gradient: const LinearGradient(
+                colors: [ThemeColors.primary, ThemeColors.secondary],
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  t.profiles.digitalMembershipCard.card.title,
+                  style: theme.textTheme.labelLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${data.firstName}\n${data.lastName}',
+                  style: theme.textTheme.headlineLarge?.copyWith(color: ThemeColors.background),
+                ),
+                if (kvMembership != null) ...[
+                  const SizedBox(height: 20),
+                  Text(
+                    '${kvMembership.division.name1} ${kvMembership.division.name2}',
+                    style: theme.textTheme.titleSmall?.copyWith(color: ThemeColors.background),
+                  ),
+                ],
+                const SizedBox(height: 80),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        RotatedBox(
+                          quarterTurns: -1,
+                          child: Text(
+                            '${t.profiles.digitalMembershipCard.card.party}\n${t.profiles.digitalMembershipCard.card.membershipNumber}\n${data.personalId}',
+                            style: theme.textTheme.labelLarge?.copyWith(color: ThemeColors.background),
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                        CustomIcon(
+                          path: 'assets/icons/sunflower.svg',
+                          height: 48,
+                          color: ThemeColors.background,
+                        ),
+                      ],
+                    ),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(20),
+                      child: QrImageView(
+                        data: data.personalId,
+                        version: QrVersions.auto,
+                        size: 212,
+                        backgroundColor: ThemeColors.background,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/profiles/screens/own_profile_screen.dart
+++ b/lib/features/profiles/screens/own_profile_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:gruene_app/app/constants/routes.dart';
 import 'package:gruene_app/app/screens/error_screen.dart';
 import 'package:gruene_app/app/screens/future_loading_screen.dart';
 import 'package:gruene_app/app/utils/open_url.dart';
+import 'package:gruene_app/app/widgets/text_list_item.dart';
 import 'package:gruene_app/features/profiles/domain/profiles_api_service.dart';
 import 'package:gruene_app/features/profiles/helper/social_media_type_translation.dart';
 import 'package:gruene_app/features/profiles/widgets/profile_base_data.dart';
@@ -34,6 +37,11 @@ class OwnProfileScreen extends StatelessWidget {
           children: [
             SizedBox(height: 24),
             ProfileHeader(profile: data),
+            SizedBox(height: 24),
+            TextListItem(
+              title: t.profiles.digitalMembershipCard.title,
+              onPress: () => context.pushNamed(Routes.digitalMembershipCard.name!),
+            ),
             SizedBox(height: 24),
             ProfileBaseData(profile: data),
             SizedBox(height: 12),

--- a/lib/i18n/app_de.json
+++ b/lib/i18n/app_de.json
@@ -218,7 +218,15 @@
       "twitter": "Twitter",
       "chatbegruenung": "Chatbegrünung"
     },
-    "homepage": "Homepage"
+    "homepage": "Homepage",
+    "digitalMembershipCard": {
+      "title": "Mein Mitgliedsausweis",
+      "card": {
+        "title": "Mitgliedskarte",
+        "party": "Bündnis 90/DIE GRÜNEN",
+        "membershipNumber": "Mitgliedernummer:"
+      }
+    }
   },
   "mfa": {
     "mfa": "Zwei-Faktor-Authentifizierung",

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1212,6 +1212,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  qr_flutter:
+    dependency: "direct main"
+    description:
+      name: qr_flutter
+      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   qs_dart:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   carousel_slider_plus: ^7.1.0
   flutter_file_dialog: ^3.0.2
   cached_network_image: ^3.4.1
+  qr_flutter: ^4.1.0
 
 dev_dependencies:
 


### PR DESCRIPTION
### Short Description

Shows the digital membership card.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add link to digital membership card on profile page
- Show digital membership card, including qr code containing the profile id

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
- Navigate to the profile page and click on "Mein Mitgliedsausweis"
- View your digital membership card.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #63

---