### PR TITLE
145: Push Notifications for News and FCM Setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,10 @@ commands:
             - run:
                 command: fvm dart run build_runner build
                 name: Generate Swagger API
+            - run:
+                command: |
+                    echo $GOOGLE_SERVICES_JSON | base64 -d > android/app/google-services.json
+                name: Restore google-services.json
     prepare_workspace:
         description: Attach the workspace at ~/attached_workspace and list its contents
         steps:

--- a/.circleci/src/commands/prepare_project.yml
+++ b/.circleci/src/commands/prepare_project.yml
@@ -6,5 +6,9 @@ steps:
       name: Apply Production Environment
       command: cp .env.prod .env
   - run:
-      command: fvm dart run build_runner build
       name: Generate Swagger API
+      command: fvm dart run build_runner build
+  - run:
+      name: Restore google-services.json
+      command: |
+        echo $GOOGLE_SERVICES_JSON | base64 -d > android/app/google-services.json

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,4 @@ report.xml
 node_modules
 
 /lib/swagger_generated_code/
+android/app/google-services.json

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,6 +3,11 @@ plugins {
     id "kotlin-android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
+    id "com.google.gms.google-services"
+}
+
+dependencies {
+  implementation platform('com.google.firebase:firebase-bom:33.10.0')
 }
 
 android {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,6 +8,7 @@ plugins {
 
 dependencies {
   implementation platform('com.google.firebase:firebase-bom:33.10.0')
+  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 }
 
 android {
@@ -18,6 +19,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -20,6 +20,7 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.3.2" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.google.gms.google-services" version "4.4.2" apply false
 }
 
 include ":app"

--- a/lib/app/constants/routes.dart
+++ b/lib/app/constants/routes.dart
@@ -10,6 +10,7 @@ import 'package:gruene_app/features/mfa/screens/token_scan_screen.dart';
 import 'package:gruene_app/features/news/screens/news_detail_screen.dart';
 import 'package:gruene_app/features/news/screens/news_screen.dart';
 import 'package:gruene_app/features/profiles/screens/own_profile_screen.dart';
+import 'package:gruene_app/features/settings/screens/push_notifications_screen.dart';
 import 'package:gruene_app/features/settings/screens/settings_screen.dart';
 import 'package:gruene_app/features/settings/screens/support_screen.dart';
 import 'package:gruene_app/features/tools/screens/tools_screen.dart';
@@ -48,10 +49,12 @@ class Routes {
   static GoRoute tools = buildRoute('/tools', t.tools.tools, ToolsScreen(), withMainLayout: false);
   static GoRoute login = buildRoute('/login', t.login.login, LoginScreen(), withMainLayout: false);
   static GoRoute support = buildRoute('support', t.settings.support.support, SupportScreen());
+  static GoRoute pushNotifications =
+      buildRoute('push-notifications', t.settings.pushNotifications.pushNotifications, PushNotificationsScreen());
   static GoRoute settings = buildRoute(
     '/settings',
     t.settings.settings,
     SettingsScreen(),
-    routes: [support],
+    routes: [pushNotifications, support],
   );
 }

--- a/lib/app/constants/secure_storage_keys.dart
+++ b/lib/app/constants/secure_storage_keys.dart
@@ -5,4 +5,5 @@ class SecureStorageKeys {
   static const String pushNotificationsBV = 'push_notifications_bv';
   static const String pushNotificationsLV = 'push_notifications_lv';
   static const String pushNotificationsKV = 'push_notifications_kv';
+  static const String subscribedTopics = 'subscribed_topics';
 }

--- a/lib/app/constants/secure_storage_keys.dart
+++ b/lib/app/constants/secure_storage_keys.dart
@@ -2,4 +2,7 @@ class SecureStorageKeys {
   static const String accessToken = 'access_token';
   static const String idToken = 'id_token';
   static const String refreshToken = 'refresh_token';
+  static const String pushNotificationsBV = 'push_notifications_bv';
+  static const String pushNotificationsLV = 'push_notifications_lv';
+  static const String pushNotificationsKV = 'push_notifications_kv';
 }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -4,8 +4,9 @@ import 'package:go_router/go_router.dart';
 import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/constants/routes.dart';
 
-GoRouter createAppRouter(BuildContext context) {
+GoRouter createAppRouter(BuildContext context, GlobalKey<NavigatorState> navigatorKey) {
   return GoRouter(
+    navigatorKey: navigatorKey,
     initialLocation: Routes.news.path,
     routes: [
       Routes.news,

--- a/lib/app/services/fcm_notification_service.dart
+++ b/lib/app/services/fcm_notification_service.dart
@@ -1,0 +1,111 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:go_router/go_router.dart';
+
+class FcmNotificationService {
+  final GlobalKey<NavigatorState> navigatorKey;
+  final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
+  final FlutterLocalNotificationsPlugin _localNotifications = FlutterLocalNotificationsPlugin();
+
+  final AndroidNotificationChannel _channel = const AndroidNotificationChannel(
+    'default_channel',
+    'Benachrichtigungen',
+    description: 'Benachrichtigungen der Grünen App',
+    importance: Importance.high,
+  );
+
+  String? _initialNewsId;
+  String? get initialNewsId => _initialNewsId;
+
+  FcmNotificationService(this.navigatorKey);
+
+  Future<void> initialize() async {
+    await Firebase.initializeApp();
+    await _firebaseMessaging.requestPermission();
+
+    await _setupLocalNotifications();
+    _registerForegroundMessageHandler();
+    _registerNotificationTapHandler();
+    _registerBackgroundHandler();
+    _handleInitialMessage();
+  }
+
+  Future<void> _handleInitialMessage() async {
+    final message = await _firebaseMessaging.getInitialMessage();
+    _initialNewsId = message?.data['newsId']?.toString();
+  }
+
+  void _registerForegroundMessageHandler() {
+    FirebaseMessaging.onMessage.listen(_handleMessage);
+  }
+
+  void _registerNotificationTapHandler() {
+    FirebaseMessaging.onMessageOpenedApp.listen((message) {
+      final newsId = message.data['newsId'];
+      if (newsId != null) {
+        _navigateTo('/news/$newsId');
+      }
+    });
+
+    _localNotifications.initialize(
+      const InitializationSettings(
+        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+      ),
+      onDidReceiveNotificationResponse: (NotificationResponse response) {
+        final payload = response.payload;
+        if (payload != null && payload.startsWith('news:')) {
+          final newsId = payload.replaceFirst('news:', '');
+          _navigateTo('/news/$newsId');
+        }
+      },
+    );
+  }
+
+  void _registerBackgroundHandler() {
+    FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+  }
+
+  Future<void> _setupLocalNotifications() async {
+    await _localNotifications
+        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(_channel);
+  }
+
+  void _handleMessage(RemoteMessage message) {
+    final notification = message.notification;
+    final newsId = message.data['newsId'];
+
+    if (notification != null) {
+      _localNotifications.show(
+        notification.hashCode,
+        notification.title ?? 'Benachrichtigung',
+        notification.body ?? '',
+        NotificationDetails(
+          android: AndroidNotificationDetails(
+            _channel.id,
+            _channel.name,
+            channelDescription: _channel.description,
+            importance: Importance.high,
+            priority: Priority.high,
+            icon: '@mipmap/ic_launcher',
+          ),
+        ),
+        payload: newsId != null ? 'news:$newsId' : null,
+      );
+    }
+  }
+
+  void _navigateTo(String route) {
+    final context = navigatorKey.currentContext;
+    if (context != null) {
+      GoRouter.of(context).go(route);
+    }
+  }
+}
+
+@pragma('vm:entry-point')
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp();
+}

--- a/lib/app/services/fcm_topic_service.dart
+++ b/lib/app/services/fcm_topic_service.dart
@@ -1,0 +1,186 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:get_it/get_it.dart';
+import 'package:gruene_app/app/constants/secure_storage_keys.dart';
+import 'package:gruene_app/app/utils/logger.dart';
+import 'package:jwt_decoder/jwt_decoder.dart';
+
+class FcmTopicService {
+  final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
+  final FlutterSecureStorage _secureStorage = GetIt.instance<FlutterSecureStorage>();
+  bool _initialized = false;
+
+  static const String topicBV = SecureStorageKeys.pushNotificationsBV;
+  static const String topicLV = SecureStorageKeys.pushNotificationsLV;
+  static const String topicKV = SecureStorageKeys.pushNotificationsKV;
+
+  FcmTopicService() {
+    _initializeAsync();
+  }
+
+  Future<void> _initializeAsync() async {
+    if (_initialized) return;
+
+    try {
+      await _firebaseMessaging.requestPermission();
+      _initialized = true;
+    } catch (e) {
+      logger.e('Failed to initialize Firebase Messaging: $e');
+    }
+  }
+
+  Future<List<Map<String, String>>?> _generateTopicsForUser() async {
+    String? accessToken = await _secureStorage.read(key: SecureStorageKeys.accessToken);
+    if (accessToken == null) {
+      return null;
+    }
+
+    List<Map<String, String>> topics = [];
+    topics.add({'topic': topicBV, 'identifier': 'news.10000000'});
+
+    List<String> memberships = (JwtDecoder.decode(accessToken)['groups'] as List?)
+            ?.map((g) => g.toString())
+            .where((group) => !group.contains('_'))
+            .toList() ??
+        [];
+
+    for (String membership in memberships) {
+      membership = membership.startsWith('2') ? '1${membership.substring(1)}' : membership;
+      if (membership.length == 3) {
+        topics.add({'topic': topicLV, 'identifier': 'news.$membership${'0' * 5}'});
+      } else if (membership.length == 8) {
+        topics.add({
+          'topic': topicKV,
+          'identifier': 'news.${membership.substring(0, membership.length - 2)}00',
+        });
+      }
+    }
+
+    return topics;
+  }
+
+  Future<Map<String, List<String>>> getAvailableTopics() async {
+    final topics = await _generateTopicsForUser();
+    final Map<String, List<String>> result = {
+      'bundesverband': [],
+      'landesverband': [],
+      'kreisverband': [],
+    };
+    if (topics == null || topics.isEmpty) {
+      return result;
+    }
+
+    for (final topic in topics) {
+      final identifier = topic['identifier'];
+
+      if (identifier != null) {
+        switch (topic['topic']) {
+          case topicBV:
+            result['bundesverband']!.add(identifier);
+            break;
+          case topicLV:
+            result['landesverband']!.add(identifier);
+            break;
+          case topicKV:
+            result['kreisverband']!.add(identifier);
+            break;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  Future<List<String>> _getSubscribedTopics() async {
+    final topicsString = await _secureStorage.read(key: SecureStorageKeys.subscribedTopics);
+    if (topicsString == null || topicsString.isEmpty) {
+      return [];
+    }
+    return topicsString.split(',');
+  }
+
+  Future<void> _saveSubscribedTopics(List<String> topics) async {
+    if (topics.isEmpty) {
+      await _secureStorage.delete(key: SecureStorageKeys.subscribedTopics);
+    } else {
+      await _secureStorage.write(key: SecureStorageKeys.subscribedTopics, value: topics.join(','));
+    }
+  }
+
+  Future<void> unsubscribeFromAllTopics() async {
+    try {
+      final subscribedTopics = await _getSubscribedTopics();
+
+      for (final topic in subscribedTopics) {
+        await _firebaseMessaging.unsubscribeFromTopic(topic);
+        logger.d('Unsubscribed from topic: $topic');
+      }
+
+      await _saveSubscribedTopics([]);
+    } catch (e) {
+      logger.w('Error unsubscribing from topics: $e');
+    }
+  }
+
+  Future<void> updateSubscriptions() async {
+    final availableTopics = await getAvailableTopics();
+    if (availableTopics.isEmpty ||
+        (availableTopics['bundesverband']!.isEmpty &&
+            availableTopics['landesverband']!.isEmpty &&
+            availableTopics['kreisverband']!.isEmpty)) {
+      logger.d('No topics available for subscription');
+      return;
+    }
+
+    final subscriptionMap = {
+      topicBV: availableTopics['bundesverband'] ?? [],
+      topicLV: availableTopics['landesverband'] ?? [],
+      topicKV: availableTopics['kreisverband'] ?? [],
+    };
+
+    final currentSubscriptions = await _getSubscribedTopics();
+    final newSubscriptions = <String>[];
+    final topicsToUnsubscribe = List.of(currentSubscriptions);
+
+    for (final entry in subscriptionMap.entries) {
+      final settingKey = entry.key;
+      final topicValues = entry.value;
+
+      if (topicValues.isEmpty) {
+        continue;
+      }
+
+      final isEnabled = await _secureStorage.read(key: settingKey) == 'true';
+
+      try {
+        for (final topicValue in topicValues) {
+          if (isEnabled) {
+            if (!currentSubscriptions.contains(topicValue)) {
+              await _firebaseMessaging.subscribeToTopic(topicValue);
+              logger.d('Subscribed to topic: $topicValue');
+            }
+            newSubscriptions.add(topicValue);
+            topicsToUnsubscribe.remove(topicValue);
+          } else if (currentSubscriptions.contains(topicValue)) {
+            topicsToUnsubscribe.remove(topicValue);
+            await _firebaseMessaging.unsubscribeFromTopic(topicValue);
+            logger.d('Unsubscribed from topic: $topicValue');
+          }
+        }
+      } catch (e) {
+        logger.w('Error managing subscriptions for ${entry.key}: $e');
+      }
+    }
+
+    for (final topic in topicsToUnsubscribe) {
+      try {
+        await _firebaseMessaging.unsubscribeFromTopic(topic);
+        logger.d('Unsubscribed from outdated topic: $topic');
+      } catch (e) {
+        logger.w('Error unsubscribing from topic $topic: $e');
+      }
+    }
+
+    await _saveSubscribedTopics(newSubscriptions);
+  }
+}

--- a/lib/app/widgets/toggle_list_item.dart
+++ b/lib/app/widgets/toggle_list_item.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:gruene_app/app/theme/theme.dart';
+
+class ToggleListItem extends StatelessWidget {
+  final String title;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  const ToggleListItem({
+    super.key,
+    required this.title,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      color: theme.colorScheme.surface,
+      margin: const EdgeInsets.only(bottom: 1),
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 24),
+        title: Text(
+          title,
+          style: theme.textTheme.bodyLarge?.apply(color: ThemeColors.text),
+        ),
+        trailing: Switch(
+          value: value,
+          onChanged: onChanged,
+          activeColor: Colors.white,
+          activeTrackColor: theme.colorScheme.primary,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/bloc/push_notifications/push_notification_settings_bloc.dart
+++ b/lib/features/settings/bloc/push_notifications/push_notification_settings_bloc.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:get_it/get_it.dart';
+import 'package:gruene_app/app/constants/secure_storage_keys.dart';
+import 'package:gruene_app/features/settings/bloc/push_notifications/push_notification_settings_event.dart';
+import 'package:gruene_app/features/settings/bloc/push_notifications/push_notification_settings_state.dart';
+
+class PushNotificationSettingsBloc extends Bloc<PushNotificationSettingsEvent, PushNotificationSettingsState> {
+  final _secureStorage = GetIt.instance<FlutterSecureStorage>();
+
+  final List<String> pushNotificationSettingKeys = [
+    SecureStorageKeys.pushNotificationsBV,
+    SecureStorageKeys.pushNotificationsLV,
+    SecureStorageKeys.pushNotificationsKV,
+  ];
+
+  PushNotificationSettingsBloc() : super(PushNotificationSettingsState({})) {
+    on<LoadPushNotificationSettings>(_onLoadPushNotificationSettings);
+    on<TogglePushNotificationSetting>(_onTogglePushNotificationSetting);
+    on<DisableAllToggles>(_onDisableAllToggles);
+  }
+
+  Future<void> _onLoadPushNotificationSettings(
+    LoadPushNotificationSettings event,
+    Emitter<PushNotificationSettingsState> emit,
+  ) async {
+    final newValues = <String, bool>{};
+    for (final key in pushNotificationSettingKeys) {
+      final value = await _secureStorage.read(key: key);
+      newValues[key] = value == 'true';
+    }
+
+    emit(PushNotificationSettingsState(newValues));
+  }
+
+  Future<void> _onTogglePushNotificationSetting(
+    TogglePushNotificationSetting event,
+    Emitter<PushNotificationSettingsState> emit,
+  ) async {
+    await _secureStorage.write(key: event.key, value: event.value.toString());
+
+    // TODO: add firebase logic to subscribe or unsubscribe to/from topic
+
+    final updated = Map<String, bool>.from(state.toggles);
+    updated[event.key] = event.value;
+
+    bool allTogglesOff = true;
+    for (final key in pushNotificationSettingKeys) {
+      if (updated[key] == true) {
+        allTogglesOff = false;
+        break;
+      }
+    }
+
+    emit(state.copyWith(toggles: updated, allDisabled: allTogglesOff));
+  }
+
+  Future<void> _onDisableAllToggles(DisableAllToggles event, Emitter<PushNotificationSettingsState> emit) async {
+    final updated = <String, bool>{};
+    for (final key in pushNotificationSettingKeys) {
+      await _secureStorage.write(key: key, value: 'false');
+      updated[key] = false;
+
+      // TODO: add firebase logic to unsubscribe from topic
+    }
+    emit(PushNotificationSettingsState(updated, allDisabled: true));
+  }
+}

--- a/lib/features/settings/bloc/push_notifications/push_notification_settings_event.dart
+++ b/lib/features/settings/bloc/push_notifications/push_notification_settings_event.dart
@@ -10,3 +10,5 @@ class TogglePushNotificationSetting extends PushNotificationSettingsEvent {
 }
 
 class DisableAllToggles extends PushNotificationSettingsEvent {}
+
+class UpdateFirebaseSubscriptions extends PushNotificationSettingsEvent {}

--- a/lib/features/settings/bloc/push_notifications/push_notification_settings_event.dart
+++ b/lib/features/settings/bloc/push_notifications/push_notification_settings_event.dart
@@ -1,0 +1,12 @@
+abstract class PushNotificationSettingsEvent {}
+
+class LoadPushNotificationSettings extends PushNotificationSettingsEvent {}
+
+class TogglePushNotificationSetting extends PushNotificationSettingsEvent {
+  final String key;
+  final bool value;
+
+  TogglePushNotificationSetting(this.key, this.value);
+}
+
+class DisableAllToggles extends PushNotificationSettingsEvent {}

--- a/lib/features/settings/bloc/push_notifications/push_notification_settings_state.dart
+++ b/lib/features/settings/bloc/push_notifications/push_notification_settings_state.dart
@@ -1,0 +1,17 @@
+class PushNotificationSettingsState {
+  final Map<String, bool> toggles;
+  final bool allDisabled;
+
+  PushNotificationSettingsState(this.toggles, {bool? allDisabled})
+      : allDisabled = allDisabled ?? toggles.values.every((v) => v == false);
+
+  PushNotificationSettingsState copyWith({
+    Map<String, bool>? toggles,
+    bool? allDisabled,
+  }) {
+    return PushNotificationSettingsState(
+      toggles ?? this.toggles,
+      allDisabled: allDisabled ?? this.allDisabled,
+    );
+  }
+}

--- a/lib/features/settings/bloc/push_notifications/push_notification_settings_state.dart
+++ b/lib/features/settings/bloc/push_notifications/push_notification_settings_state.dart
@@ -1,16 +1,22 @@
 class PushNotificationSettingsState {
   final Map<String, bool> toggles;
+  final Set<String> availableToggles;
   final bool allDisabled;
 
-  PushNotificationSettingsState(this.toggles, {bool? allDisabled})
-      : allDisabled = allDisabled ?? toggles.values.every((v) => v == false);
+  const PushNotificationSettingsState(
+    this.toggles, {
+    this.availableToggles = const {},
+    this.allDisabled = false,
+  });
 
   PushNotificationSettingsState copyWith({
     Map<String, bool>? toggles,
+    Set<String>? availableToggles,
     bool? allDisabled,
   }) {
     return PushNotificationSettingsState(
       toggles ?? this.toggles,
+      availableToggles: availableToggles ?? this.availableToggles,
       allDisabled: allDisabled ?? this.allDisabled,
     );
   }

--- a/lib/features/settings/screens/push_notifications_screen.dart
+++ b/lib/features/settings/screens/push_notifications_screen.dart
@@ -17,15 +17,17 @@ class PushNotificationsScreen extends StatelessWidget {
       SecureStorageKeys.pushNotificationsLV: t.settings.pushNotifications.pushNotificationsLV,
       SecureStorageKeys.pushNotificationsKV: t.settings.pushNotifications.pushNotificationsKV,
     };
+
     return BlocBuilder<PushNotificationSettingsBloc, PushNotificationSettingsState>(
       builder: (context, state) {
         final bloc = context.read<PushNotificationSettingsBloc>();
 
+        final availableToggleEntries =
+            state.toggles.entries.where((entry) => state.availableToggles.contains(entry.key)).toList();
+
         return ListView(
           children: [
-            SizedBox(
-              height: 36,
-            ),
+            SizedBox(height: 36),
             ToggleListItem(
               title: t.settings.pushNotifications.disableAll,
               value: state.allDisabled,
@@ -35,7 +37,7 @@ class PushNotificationsScreen extends StatelessWidget {
                 }
               },
             ),
-            ...state.toggles.entries.map((entry) {
+            ...availableToggleEntries.map((entry) {
               return ToggleListItem(
                 title: localizedTitles[entry.key]!,
                 value: entry.value,

--- a/lib/features/settings/screens/push_notifications_screen.dart
+++ b/lib/features/settings/screens/push_notifications_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gruene_app/app/constants/secure_storage_keys.dart';
+import 'package:gruene_app/app/widgets/toggle_list_item.dart';
+import 'package:gruene_app/features/settings/bloc/push_notifications/push_notification_settings_bloc.dart';
+import 'package:gruene_app/features/settings/bloc/push_notifications/push_notification_settings_event.dart';
+import 'package:gruene_app/features/settings/bloc/push_notifications/push_notification_settings_state.dart';
+import 'package:gruene_app/i18n/translations.g.dart';
+
+class PushNotificationsScreen extends StatelessWidget {
+  const PushNotificationsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final Map<String, String> localizedTitles = {
+      SecureStorageKeys.pushNotificationsBV: t.settings.pushNotifications.pushNotificationsBV,
+      SecureStorageKeys.pushNotificationsLV: t.settings.pushNotifications.pushNotificationsLV,
+      SecureStorageKeys.pushNotificationsKV: t.settings.pushNotifications.pushNotificationsKV,
+    };
+    return BlocBuilder<PushNotificationSettingsBloc, PushNotificationSettingsState>(
+      builder: (context, state) {
+        final bloc = context.read<PushNotificationSettingsBloc>();
+
+        return ListView(
+          children: [
+            SizedBox(
+              height: 36,
+            ),
+            ToggleListItem(
+              title: t.settings.pushNotifications.disableAll,
+              value: state.allDisabled,
+              onChanged: (value) {
+                if (value) {
+                  bloc.add(DisableAllToggles());
+                }
+              },
+            ),
+            ...state.toggles.entries.map((entry) {
+              return ToggleListItem(
+                title: localizedTitles[entry.key]!,
+                value: entry.value,
+                onChanged: (bool newValue) {
+                  bloc.add(TogglePushNotificationSetting(entry.key, newValue));
+                },
+              );
+            }),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -26,7 +26,10 @@ class SettingsScreen extends StatelessWidget {
         TextListItem(title: t.settings.inviteNonMember, onPress: () => {}, isImplemented: false),
         TextListItem(title: t.settings.offlineMaps, onPress: () => {}, isImplemented: false),
         SectionTitle(title: t.settings.generalSettings),
-        TextListItem(title: t.settings.pushNotifications, onPress: () => {}, isImplemented: false),
+        TextListItem(
+          title: t.settings.pushNotifications.pushNotifications,
+          onPress: () => context.pushNamed(Routes.pushNotifications.name!),
+        ),
         TextListItem(title: t.settings.accessibility, onPress: () => {}, isImplemented: false),
         TextListItem(
           title: t.settings.support.support,

--- a/lib/i18n/app_de.json
+++ b/lib/i18n/app_de.json
@@ -276,8 +276,14 @@
     "inviteNonMember": "Nicht-Mitglied einladen",
     "offlineMaps": "Offline-Karten",
     "generalSettings": "App",
-    "pushNotifications": "Push Nachrichten",
     "accessibility": "Barrierefreiheit",
+    "pushNotifications": {
+      "pushNotifications": "Push Nachrichten",
+      "disableAll": "Vollständig deaktivieren",
+      "pushNotificationsBV": "News Bundesverband",
+      "pushNotificationsLV": "News Landesverband",
+      "pushNotificationsKV": "News Kreisverband"
+    },
     "support": {
       "support": "Support & Feedback",
       "contacts": "Kontakte für Support & Feedback zur App",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,8 @@ import 'package:gruene_app/features/campaigns/helper/file_cache_manager.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_bloc.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_event.dart';
 import 'package:gruene_app/features/mfa/domain/mfa_factory.dart';
+import 'package:gruene_app/features/settings/bloc/push_notifications/push_notification_settings_bloc.dart';
+import 'package:gruene_app/features/settings/bloc/push_notifications/push_notification_settings_event.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -123,6 +125,7 @@ class MyApp extends StatelessWidget {
         BlocProvider(
           create: (context) => MfaBloc()..add(InitMfa()),
         ),
+        BlocProvider(create: (context) => PushNotificationSettingsBloc()..add(LoadPushNotificationSettings())),
       ],
       child: Builder(
         builder: (context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -310,6 +310,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.7"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   dio:
     dependency: "direct main"
     description:
@@ -587,6 +595,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: ced76d337f54de33d7d9f06092137b4ac2da5079e00cee8a11a1794ffc7c61c6
+      url: "https://pub.dev"
+    source: hosted
+    version: "17.2.1"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -1542,6 +1574,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.7.0"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
   timing:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "72.0.0"
+  _flutterfire_internals:
+    dependency: transitive
+    description:
+      name: _flutterfire_internals
+      sha256: "7fd72d77a7487c26faab1d274af23fb008763ddc10800261abbfb2c067f183d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.53"
   _macros:
     dependency: transitive
     description: dart
@@ -58,10 +66,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.0"
   benchmark:
     dependency: transitive
     description:
@@ -82,10 +90,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
@@ -334,6 +342,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -382,6 +398,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3+3"
+  firebase_core:
+    dependency: "direct main"
+    description:
+      name: firebase_core
+      sha256: f4d8f49574a4e396f34567f3eec4d38ab9c3910818dec22ca42b2a467c685d8b
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.12.1"
+  firebase_core_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_core_platform_interface
+      sha256: d7253d255ff10f85cfd2adaba9ac17bae878fa3ba577462451163bd9f1d1f0bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.4.0"
+  firebase_core_web:
+    dependency: transitive
+    description:
+      name: firebase_core_web
+      sha256: faa5a76f6380a9b90b53bc3bdcb85bc7926a382e0709b9b5edac9f7746651493
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.21.1"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: "5fc345c6341f9dc69fd0ffcbf508c784fd6d1b9e9f249587f30434dd8b6aa281"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.2.4"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: a935924cf40925985c8049df4968b1dde5c704f570f3ce380b31d3de6990dd94
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.4"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: fafebf6a1921931334f3f10edb5037a5712288efdd022881e2d093e5654a2fd4
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.10.4"
   fixnum:
     dependency: transitive
     description:
@@ -600,6 +664,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.10+1"
+  flutter_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -876,6 +945,30 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.5"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -992,10 +1085,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1373,10 +1466,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
@@ -1397,10 +1490,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "0bd04f5bb74fcd6ff0606a888a30e917af9bd52820b178eaa464beb11dca84b6"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.2.0"
   swagger_dart_code_generator:
     dependency: "direct dev"
     description:
@@ -1437,10 +1530,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   timeago:
     dependency: "direct main"
     description:
@@ -1609,6 +1702,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,8 @@ dependencies:
   carousel_slider_plus: ^7.1.0
   flutter_file_dialog: ^3.0.2
   cached_network_image: ^3.4.1
+  firebase_messaging: ^15.0.0
+  firebase_core: ^3.12.1
 
 dev_dependencies:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   cached_network_image: ^3.4.1
   firebase_messaging: ^15.0.0
   firebase_core: ^3.12.1
+  flutter_local_notifications: 17.2.1
 
 dev_dependencies:
 


### PR DESCRIPTION
### Short Description

Adds the possibility for the user to configure push notifications for news about his Bundesverband, Landesverand and Kreisverband.

### Proposed Changes

- Adds push notifications settings page
- Automatic handling of subscriptions to the specific news topics
- Show notifications if the app is in foreground, background or closed

### Side Effects

None.

### Testing

- Navigate to push notifications page and configure settings
- Receive push notifications
- Click on push notifications to get navigated to the news details

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #145, #143

---