### PR TITLE
646: Use bookmark button instead of tabs

### DIFF
--- a/lib/app/utils/utils.dart
+++ b/lib/app/utils/utils.dart
@@ -30,8 +30,8 @@ extension WithDividers on Iterable<Widget> {
 }
 
 extension PushNested on BuildContext {
-  void pushNested(String nestedSlug) {
+  void pushNested(String nestedSlug, {Object? extra}) {
     final currentPath = GoRouterState.of(this).fullPath;
-    push('$currentPath/$nestedSlug');
+    push('$currentPath/$nestedSlug', extra: extra);
   }
 }

--- a/lib/features/news/screens/news_detail_screen.dart
+++ b/lib/features/news/screens/news_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:gruene_app/app/screens/error_screen.dart';
 import 'package:gruene_app/app/screens/future_loading_screen.dart';
 import 'package:gruene_app/app/utils/divisions.dart';
@@ -19,11 +20,12 @@ class NewsDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final newsItem = GoRouterState.of(context).extra as NewsModel?;
     final theme = Theme.of(context);
     return Scaffold(
       appBar: MainAppBar(title: t.news.newsDetail),
       body: FutureLoadingScreen<NewsModel?>(
-        load: () => fetchNewsById(newsId),
+        load: newsItem == null ? () => fetchNewsById(newsId) : () async => newsItem,
         buildChild: (NewsModel? news) {
           if (news == null) {
             return ErrorScreen(errorMessage: t.news.newsNotFound, retry: () => fetchNewsById(newsId));

--- a/lib/features/news/screens/news_screen.dart
+++ b/lib/features/news/screens/news_screen.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gruene_app/app/screens/future_loading_screen.dart';
-import 'package:gruene_app/app/screens/tab_screen.dart';
 import 'package:gruene_app/app/utils/divisions.dart';
 import 'package:gruene_app/app/widgets/app_bar.dart';
-import 'package:gruene_app/app/widgets/tab_bar.dart';
 import 'package:gruene_app/features/news/domain/news_api_service.dart';
 import 'package:gruene_app/features/news/models/news_model.dart';
 import 'package:gruene_app/features/news/utils/utils.dart';
@@ -17,28 +15,12 @@ class NewsScreenContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TabScreen(
-      appBarBuilder: (PreferredSizeWidget tabBar) => MainAppBar(title: t.news.news, tabBar: tabBar),
-      tabs: [
-        TabModel(
-          label: t.news.latest,
-          view: Builder(
-            builder: (context) => FutureLoadingScreen<List<NewsModel>>(
-              load: fetchNews,
-              buildChild: (List<NewsModel> news) => NewsScreen(news: news),
-            ),
-          ),
-        ),
-        TabModel(
-          label: t.news.bookmarked,
-          view: Builder(
-            builder: (context) => FutureLoadingScreen<List<NewsModel>>(
-              load: () => fetchNews(bookmarked: true),
-              buildChild: (List<NewsModel> news) => NewsScreen(news: news),
-            ),
-          ),
-        ),
-      ],
+    return Scaffold(
+      appBar: MainAppBar(title: t.news.news),
+      body: FutureLoadingScreen(
+        load: fetchNews,
+        buildChild: (List<NewsModel> news) => NewsScreen(news: news),
+      ),
     );
   }
 }

--- a/lib/features/news/widgets/news_card.dart
+++ b/lib/features/news/widgets/news_card.dart
@@ -103,7 +103,7 @@ class NewsCard extends StatelessWidget {
               child: Material(
                 color: Colors.transparent,
                 child: InkWell(
-                  onTap: () => context.pushNested(news.id),
+                  onTap: () => context.pushNested(news.id, extra: news),
                   customBorder: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(8.0),
                   ),

--- a/lib/features/news/widgets/news_list.dart
+++ b/lib/features/news/widgets/news_list.dart
@@ -28,9 +28,11 @@ class NewsList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FutureLoadingScreen(
-      load: query.isNotEmpty ? () => fetchNews(query: query) : () async => allNews,
+      load: query.isNotEmpty || showBookmarked
+          ? () => fetchNews(query: query, bookmarked: showBookmarked)
+          : () async => allNews,
       buildChild: (List<NewsModel> data) {
-        final news = data.filter(selectedDivisions, selectedCategories, showBookmarked, dateRange);
+        final news = data.filter(selectedDivisions, selectedCategories, false, dateRange);
         if (news.isEmpty) {
           return ErrorScreen(errorMessage: t.news.noResults, retry: fetchNews);
         }

--- a/lib/features/news/widgets/news_search_filter_bar.dart
+++ b/lib/features/news/widgets/news_search_filter_bar.dart
@@ -46,16 +46,15 @@ class NewsSearchFilterBar extends StatelessWidget {
         mainAxisSize: MainAxisSize.max,
         children: [
           Flexible(child: CustomSearchBar(setQuery: setQuery, query: query)),
-          // TODO #213: Add bookmarking functionality
-          // SizedBox(width: 8),
-          // RoundedIconButton(
-          //   onPressed: () => setState(() => showBookmarked = !showBookmarked),
-          //   icon: Icons.bookmark_outline,
-          //   iconColor: ThemeColors.textDisabled,
-          //   backgroundColor: theme.colorScheme.surface,
-          //   selected: showBookmarked,
-          //   width: 40,
-          // ),
+          SizedBox(width: 8),
+          RoundedIconButton(
+            onPressed: () => setShowBookmarked(!showBookmarked),
+            icon: Icons.bookmark_outline,
+            iconColor: ThemeColors.textDisabled,
+            backgroundColor: theme.colorScheme.surface,
+            selected: showBookmarked,
+            width: 40,
+          ),
           SizedBox(width: 8),
           RoundedIconButton(
             icon: Icons.tune,


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Use bookmark button instead of tabs as specified in the latest figma screens.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use bookmark filter button instead of tabs
- Pass news item as extra param to news detail screen to avoid refetching

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
1. Go to news screen
2. Add/delete bookmarks in news cards and news details
3. Activate the bookmarked filter

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #646

---