### PR TITLE
668: Remove shadow and fix color for home indicator

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -21,7 +21,7 @@ GoRouter createAppRouter(BuildContext context, GlobalKey<NavigatorState> navigat
           return Scaffold(
             appBar: AppBar(backgroundColor: theme.colorScheme.primary, toolbarHeight: 0),
             body: SafeArea(child: navigationShell),
-            bottomNavigationBar: SafeArea(child: BottomNavigation(navigationShell: navigationShell)),
+            bottomNavigationBar: BottomNavigation(navigationShell: navigationShell),
           );
         },
         branches: [

--- a/lib/app/widgets/bottom_navigation.dart
+++ b/lib/app/widgets/bottom_navigation.dart
@@ -27,15 +27,12 @@ class BottomNavigation extends StatelessWidget {
       return BottomNavigationBarItem(icon: icon, label: item.label);
     }).toList();
 
-    return SizedBox(
-      height: 64,
-      child: BottomNavigationBar(
-        type: BottomNavigationBarType.fixed,
-        backgroundColor: theme.colorScheme.surface,
-        items: items,
-        currentIndex: navigationShell.currentIndex,
-        onTap: (index) => navigationShell.goBranch(index, initialLocation: index == navigationShell.currentIndex),
-      ),
+    return BottomNavigationBar(
+      type: BottomNavigationBarType.fixed,
+      backgroundColor: theme.colorScheme.surface,
+      items: items,
+      currentIndex: navigationShell.currentIndex,
+      onTap: (index) => navigationShell.goBranch(index, initialLocation: index == navigationShell.currentIndex),
     );
   }
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Remove shadow and fix color for home indicator by removing a (hopefully) redundant `SafeAreaView`.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove the `SafeAreaView` and the height around the bottom navigation bar to make the bottom navigation bar correctly expand

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Hopefully none.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test this on different iOS and android devices.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #668

### Additional Information

---