### PR TITLE
673: Update icons

### DIFF
--- a/lib/app/widgets/text_list_item.dart
+++ b/lib/app/widgets/text_list_item.dart
@@ -35,10 +35,7 @@ class TextListItem extends StatelessWidget {
           width: 24,
           child:
               trailing ??
-              Icon(
-                isExternal ? Icons.open_in_browser_outlined : Icons.chevron_right_outlined,
-                color: theme.disabledColor,
-              ),
+              Icon(isExternal ? Icons.arrow_outward : Icons.chevron_right_outlined, color: theme.disabledColor),
         ),
         tileColor: theme.colorScheme.surface,
         contentPadding: const EdgeInsets.symmetric(horizontal: 24),

--- a/lib/features/news/widgets/news_search_filter_bar.dart
+++ b/lib/features/news/widgets/news_search_filter_bar.dart
@@ -59,7 +59,7 @@ class NewsSearchFilterBar extends StatelessWidget {
           ),
           SizedBox(width: 8),
           RoundedIconButton(
-            icon: Icons.tune,
+            icon: Icons.filter_list,
             iconColor: customFilterSelected ? theme.colorScheme.secondary : ThemeColors.textDisabled,
             backgroundColor: theme.colorScheme.surface,
             width: 40,

--- a/lib/features/profiles/widgets/profile_box_item.dart
+++ b/lib/features/profiles/widgets/profile_box_item.dart
@@ -13,7 +13,7 @@ class ProfileBoxItem extends StatelessWidget {
       contentPadding: EdgeInsets.symmetric(horizontal: 16),
       title: Text(title, style: theme.textTheme.bodyLarge),
       onTap: onPress,
-      trailing: onPress != null ? Icon(Icons.open_in_browser_outlined, color: theme.primaryColor) : null,
+      trailing: onPress != null ? Icon(Icons.arrow_outward, color: theme.primaryColor) : null,
     );
   }
 }

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/constants/routes.dart';
 import 'package:gruene_app/app/constants/urls.dart';
-import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/app/utils/open_url.dart';
 import 'package:gruene_app/app/utils/utils.dart';
 import 'package:gruene_app/app/widgets/app_bar.dart';
@@ -18,7 +17,6 @@ class SettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final authBloc = context.read<AuthBloc>();
     final isLoggedIn = authBloc.state is Authenticated;
     return Scaffold(
@@ -57,15 +55,10 @@ class SettingsScreen extends StatelessWidget {
           isLoggedIn
               ? Padding(
                   padding: const EdgeInsets.only(top: 24),
-                  child: TextButton(
+                  child: OutlinedButton.icon(
                     onPressed: () => context.read<AuthBloc>().add(LogoutRequested()),
-                    child: Text(
-                      t.settings.logout,
-                      style: theme.textTheme.bodyMedium!.apply(
-                        color: ThemeColors.text,
-                        decoration: TextDecoration.underline,
-                      ),
-                    ),
+                    label: Text(t.settings.logout),
+                    icon: Icon(Icons.logout),
                   ),
                 )
               : Container(),

--- a/lib/features/settings/widgets/settings_card.dart
+++ b/lib/features/settings/widgets/settings_card.dart
@@ -48,7 +48,7 @@ class SettingsCard extends StatelessWidget {
               ? Padding(
                   padding: const EdgeInsets.only(right: 10),
                   child: Icon(
-                    isExternal ? Icons.open_in_browser_outlined : Icons.chevron_right_outlined,
+                    isExternal ? Icons.arrow_outward : Icons.chevron_right_outlined,
                     color: theme.disabledColor,
                   ),
                 )


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Update icons to align with the new icons in line with the atlas.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Replace `open_in_browser` with `arrow_outward` for links
- Replace `tune` with `filter_list` for news list filter
- Add `logout` icon and change to outlined button for logout in settings

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check the app for usages of the replaced icons.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #673

---