### PR TITLE
change membership identity card to membership card 

### DIFF
--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -252,7 +252,7 @@
     "digitalMembershipCard": {
       "title": "Mein Mitgliedsausweis",
       "card": {
-        "title": "Mitgliedskarte",
+        "title": "Mitgliedsausweis",
         "party": "Bündnis 90/DIE GRÜNEN",
         "membershipNumber": "Mitgliedernummer:"
       }


### PR DESCRIPTION
### Short Description

In the tab "Mein Mitgliedsausweis", the membership card currently displays the label "Mitgliedskarte" (membership identity card). This PR updates the label to "Mitgliedsausweis" (membership card) for consistency.

### Proposed Changes

- Show "Mitgliedsausweis" instead of "Mitgliedskarte"

### Side Effects

- None.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

1. Go to member area
2. Click on 'Mein Mitgliedsausweis'
3. Check text

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->


Fixes: #

---