### PR TITLE
Revert #704: Use membership card wording

### DIFF
--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -250,9 +250,9 @@
     },
     "homepage": "Homepage",
     "digitalMembershipCard": {
-      "title": "Mein Mitgliedsausweis",
+      "title": "Meine Mitgliedskarte",
       "card": {
-        "title": "Mitgliedsausweis",
+        "title": "Mitgliedskarte",
         "party": "BÜNDNIS 90/DIE GRÜNEN",
         "membershipNumber": "Mitgliedernummer:"
       }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR reverts #704 and aligns the wording to "Mitgliedskarte" (membership card).

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Change the wording to membership card

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check your profile and the membership card.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---