### PR TITLE
762: remove the layer 'Besuchte Gebiete' (prototype) from the layer s…

### DIFF
--- a/lib/features/campaigns/screens/doors_screen.dart
+++ b/lib/features/campaigns/screens/doors_screen.dart
@@ -29,13 +29,7 @@ class DoorsScreen extends StatefulWidget {
 
 class _DoorsScreenState extends MapConsumer<DoorsScreen, DoorCreateModel, DoorDetailModel, DoorUpdateModel> {
   static const _poiType = PoiServiceType.door;
-  final Map<String, List<String>> doorsExclusions = <String, List<String>>{
-    t.campaigns.filters.focusAreas: [t.campaigns.filters.visited_areas],
-    t.campaigns.filters.visited_areas: [t.campaigns.filters.focusAreas],
-  };
-
   late List<FilterChipModel> doorsFilter;
-
   final _grueneApiService = GetIt.I<GrueneApiDoorService>();
 
   _DoorsScreenState() : super(_poiType);
@@ -46,7 +40,6 @@ class _DoorsScreenState extends MapConsumer<DoorsScreen, DoorCreateModel, DoorDe
   @override
   void initState() {
     doorsFilter = [
-      FilterChipModel(text: t.campaigns.filters.visited_areas, isEnabled: false),
       FilterChipModel(
         text: t.campaigns.filters.routes,
         isEnabled: true,
@@ -91,7 +84,7 @@ class _DoorsScreenState extends MapConsumer<DoorsScreen, DoorCreateModel, DoorDe
 
     return Column(
       children: [
-        FilterChipCampaign(doorsFilter, doorsExclusions),
+        FilterChipCampaign(doorsFilter),
         Expanded(child: Stack(children: [mapContainer, ...getSearchWidgets(context)])),
       ],
     );

--- a/lib/features/campaigns/screens/flyer_screen.dart
+++ b/lib/features/campaigns/screens/flyer_screen.dart
@@ -38,7 +38,6 @@ class _FlyerScreenState extends MapConsumer<FlyerScreen, FlyerCreateModel, Flyer
   @override
   void initState() {
     flyerFilter = [
-      FilterChipModel(text: t.campaigns.filters.visited_areas, isEnabled: false),
       FilterChipModel(
         text: t.campaigns.filters.focusAreas,
         isEnabled: true,
@@ -83,7 +82,7 @@ class _FlyerScreenState extends MapConsumer<FlyerScreen, FlyerCreateModel, Flyer
 
     return Column(
       children: [
-        FilterChipCampaign(flyerFilter, <String, List<String>>{}),
+        FilterChipCampaign(flyerFilter),
         Expanded(child: Stack(children: [mapContainer, ...getSearchWidgets(context)])),
       ],
     );

--- a/lib/features/campaigns/screens/posters_screen.dart
+++ b/lib/features/campaigns/screens/posters_screen.dart
@@ -93,7 +93,7 @@ class _PostersScreenState extends MapConsumer<PostersScreen, PosterCreateModel, 
 
     return Column(
       children: [
-        FilterChipCampaign(postersFilter, <String, List<String>>{}),
+        FilterChipCampaign(postersFilter),
         Expanded(
           child: Stack(
             children: [

--- a/lib/features/campaigns/widgets/filter_chip_widget.dart
+++ b/lib/features/campaigns/widgets/filter_chip_widget.dart
@@ -15,9 +15,9 @@ class FilterChipModel {
 
 class FilterChipCampaign extends StatefulWidget {
   final List<FilterChipModel> filterOptions;
-  final Map<String, List<String>> filterExclusions;
+  final Map<String, List<String>>? filterExclusions;
 
-  const FilterChipCampaign(this.filterOptions, this.filterExclusions, {super.key});
+  const FilterChipCampaign(this.filterOptions, {this.filterExclusions, super.key});
 
   @override
   State<FilterChipCampaign> createState() => _FilterChipCampaignState();
@@ -38,8 +38,12 @@ class _FilterChipCampaignState extends State<FilterChipCampaign> {
   }
 
   void unselectExclusions(FilterChipModel item) {
-    var filterExclusions = widget.filterExclusions;
-    filterExclusions.entries.where((x) => x.key == item.text).map((x) => x.value).forEach((x) => x.forEach(unselect));
+    if (widget.filterExclusions != null) {
+      widget.filterExclusions?.entries
+          .where((x) => x.key == item.text)
+          .map((x) => x.value)
+          .forEach((v) => v.forEach(unselect));
+    }
   }
 
   @override

--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -64,7 +64,6 @@
     "filters": {
       "focusAreas": "Fokusgebiete",
       "routes": "Routen",
-      "visited_areas": "Besuchte Gebiete",
       "polling_stations": "Wahllokale",
       "experience_areas": "Erfahrungsgebiete",
       "action_areas": "Einsatzgebiete"


### PR DESCRIPTION
…elector

### Short Description

<!-- Describe this PR in one or two sentences. -->
Removes a disabled layer 'Besuchte Gebiete' from the code. It came originally from the prototype and is not needed anymore

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #762 

---