### PR TITLE
794: Fix font weight

### DIFF
--- a/lib/app/theme/theme.dart
+++ b/lib/app/theme/theme.dart
@@ -49,7 +49,7 @@ class _ThemeTextStyles {
   static TextStyle displayMedium = TextStyle(
     fontFamily: 'GrueneTypeNeue',
     fontSize: 18,
-    fontWeight: FontWeight.w900,
+    fontWeight: FontWeight.w400,
     height: 1.6,
     letterSpacing: 0.02,
     color: ThemeColors.text,


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Use the correct font weight of 400 for the GrueneTypeNeue.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use the correct font weight of 400 for the GrueneTypeNeue.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Checkout the headings.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #794

---