### PR TITLE
749: allow up to 10 members to be added upon team creation

### DIFF
--- a/lib/features/campaigns/screens/teams/new_team_select_team_member_widget.dart
+++ b/lib/features/campaigns/screens/teams/new_team_select_team_member_widget.dart
@@ -82,7 +82,14 @@ class _NewTeamSelectTeamMemberWidgetState extends State<NewTeamSelectTeamMemberW
                     }
                   },
                 ),
-                ...(List<int>.generate(4, (i) => i + 1).map((i) => _getMemberWidget(i - 1))),
+                SizedBox(
+                  height: 150,
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [...(List<int>.generate(9, (i) => i + 1).map((i) => _getMemberWidget(i - 1)))],
+                    ),
+                  ),
+                ),
               ],
             ),
           ],


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
the list of initial slots is extended so that up to 10 members can be used on the initialization of a team

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---