### PR TITLE
297: allow to pull the team screen down to reload

### DIFF
--- a/lib/features/campaigns/screens/teams_screen.dart
+++ b/lib/features/campaigns/screens/teams_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_user_service.dart';
+import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/new_team_mixin.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/team_home.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
@@ -45,7 +46,14 @@ class _TeamsScreenState extends State<TeamsScreen> with NewTeamMixin {
     rows.add(TeamHome(currentUser: _currentUserInfo));
     rows.add(_currentUserInfo.isCampaignManager() ? getNewTeamButton(context) : SizedBox.shrink());
 
-    return SingleChildScrollView(child: Column(children: rows));
+    return RefreshIndicator(
+      color: ThemeColors.primary,
+      backgroundColor: ThemeColors.sun,
+      onRefresh: () {
+        return Future.delayed(Duration.zero, reload);
+      },
+      child: SingleChildScrollView(child: Column(children: rows)),
+    );
   }
 
   @override


### PR DESCRIPTION
### Short Description

reload teams screen by pulling down the screen
<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---