### PR TITLE
297 load team after create

### DIFF
--- a/lib/features/campaigns/screens/teams/new_team_mixin.dart
+++ b/lib/features/campaigns/screens/teams/new_team_mixin.dart
@@ -14,6 +14,8 @@ import 'package:gruene_app/features/campaigns/screens/teams/new_team_select_team
 import 'package:gruene_app/i18n/translations.g.dart';
 
 mixin NewTeamMixin {
+  void reload();
+
   GestureDetector getNewTeamButton(BuildContext context) {
     final theme = Theme.of(context);
     return GestureDetector(
@@ -133,6 +135,7 @@ mixin NewTeamMixin {
 
         try {
           await teamService.createNewTeam(newDetails);
+          if (isCreatingUserInNewTeam) reload();
           canceledOrSaved = true;
         } on ApiException catch (e) {
           if (context.mounted) showSnackBar(context, e.message);

--- a/lib/features/campaigns/screens/teams_screen.dart
+++ b/lib/features/campaigns/screens/teams_screen.dart
@@ -46,4 +46,9 @@ class _TeamsScreenState extends State<TeamsScreen> with NewTeamMixin {
 
     return SingleChildScrollView(child: Column(children: rows));
   }
+
+  @override
+  void reload() {
+    _loadData();
+  }
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
the team screen needs to be reloaded if the user created a team and joined by itself

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---