### PR TITLE
736: enable assigned elements for teams on team home

### DIFF
--- a/lib/app/services/converters.dart
+++ b/lib/app/services/converters.dart
@@ -30,6 +30,7 @@ import 'package:gruene_app/features/campaigns/models/route/route_assignment_upda
 import 'package:gruene_app/features/campaigns/models/route/route_detail_model.dart';
 import 'package:gruene_app/features/campaigns/models/route/route_update_model.dart';
 import 'package:gruene_app/features/campaigns/models/team/new_team_details.dart';
+import 'package:gruene_app/features/campaigns/models/team/team_assignment.dart';
 import 'package:gruene_app/features/campaigns/widgets/enhanced_wheel_slider.dart';
 import 'package:gruene_app/features/campaigns/widgets/text_input_field.dart';
 import 'package:gruene_app/i18n/translations.g.dart';

--- a/lib/app/services/converters/action_area_parsing.dart
+++ b/lib/app/services/converters/action_area_parsing.dart
@@ -20,3 +20,48 @@ extension ActionAreaListParsing on List<Area> {
     return map((p) => p.asActionAreaDetail().transformToFeatureItem()).toList();
   }
 }
+
+extension AreaAssignmentParsing on AreaAssignment {
+  AssignedElement asAssignedElement() {
+    return AssignedElement(
+      status: status.asTeamAsssignmentStatus(),
+      name: name ?? '',
+      type: type.asTeamAssignmentType(),
+      elementType: AssignedElementType.area,
+      assignmentDate: assignedAt ?? DateTime.now(),
+      assignee: assigningUser,
+      coords: polygon.asTurfPolygon(),
+    );
+  }
+}
+
+extension on AreaAssignmentStatus {
+  TeamAssignmentStatus asTeamAsssignmentStatus() {
+    switch (this) {
+      case AreaAssignmentStatus.open:
+        return TeamAssignmentStatus.open;
+      case AreaAssignmentStatus.closed:
+        return TeamAssignmentStatus.closed;
+
+      case AreaAssignmentStatus.assigned:
+      case AreaAssignmentStatus.swaggerGeneratedUnknown:
+        throw UnimplementedError();
+    }
+  }
+}
+
+extension on AreaAssignmentType {
+  TeamAssignmentType asTeamAssignmentType() {
+    switch (this) {
+      case AreaAssignmentType.flyerSpot:
+        return TeamAssignmentType.flyer;
+      case AreaAssignmentType.poster:
+        return TeamAssignmentType.poster;
+      case AreaAssignmentType.house:
+        return TeamAssignmentType.door;
+
+      case AreaAssignmentType.swaggerGeneratedUnknown:
+        throw UnimplementedError();
+    }
+  }
+}

--- a/lib/app/services/converters/route_parsing.dart
+++ b/lib/app/services/converters/route_parsing.dart
@@ -20,16 +20,46 @@ extension RouteListParsing on List<Route> {
   }
 }
 
-extension RouteTypeParsing on RouteType {
-  RouteType asTeamRouteType() {
+extension RouteAssignmentParsing on RouteAssignment {
+  AssignedElement asAssignedElement() {
+    return AssignedElement(
+      status: status.asTeamAsssignmentStatus(),
+      name: name ?? '',
+      type: type.asTeamAssignmentType(),
+      elementType: AssignedElementType.route,
+      assignmentDate: assignedAt ?? DateTime.now(),
+      assignee: assigningUser,
+      coords: lineString.asTurfLine(),
+    );
+  }
+}
+
+extension on RouteAssignmentType {
+  TeamAssignmentType asTeamAssignmentType() {
     switch (this) {
-      case RouteType.flyerSpot:
-        return RouteType.flyerSpot;
-      case RouteType.poster:
-        return RouteType.poster;
-      case RouteType.house:
-        return RouteType.house;
-      case RouteType.swaggerGeneratedUnknown:
+      case RouteAssignmentType.flyerSpot:
+        return TeamAssignmentType.flyer;
+      case RouteAssignmentType.poster:
+        return TeamAssignmentType.poster;
+      case RouteAssignmentType.house:
+        return TeamAssignmentType.door;
+
+      case RouteAssignmentType.swaggerGeneratedUnknown:
+        throw UnimplementedError();
+    }
+  }
+}
+
+extension on RouteAssignmentStatus {
+  TeamAssignmentStatus asTeamAsssignmentStatus() {
+    switch (this) {
+      case RouteAssignmentStatus.open:
+        return TeamAssignmentStatus.open;
+      case RouteAssignmentStatus.closed:
+        return TeamAssignmentStatus.closed;
+
+      case RouteAssignmentStatus.assigned:
+      case RouteAssignmentStatus.swaggerGeneratedUnknown:
         throw UnimplementedError();
     }
   }

--- a/lib/app/services/gruene_api_teams_service.dart
+++ b/lib/app/services/gruene_api_teams_service.dart
@@ -6,6 +6,9 @@ import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 class GrueneApiTeamsService extends GrueneApiBaseService {
   Future<Team?> getOwnTeam() async => getFromApi<Team?, Team?>(apiRequest: (api) => api.v1CampaignsTeamsSelfGet());
 
+  Future<TeamAssignmentResponse> getTeamAssignments({required String teamId}) =>
+      getFromApi(apiRequest: (api) => api.v1CampaignsTeamsTeamIdAssignmentsGet(teamId: teamId));
+
   Future<Team> updateTeam({required String teamId, required String teamName, String? teamDescription}) async =>
       getFromApi<Team, Team>(
         apiRequest: (api) => api.v1CampaignsTeamsTeamIdPut(

--- a/lib/features/campaigns/models/team/team_assignment.dart
+++ b/lib/features/campaigns/models/team/team_assignment.dart
@@ -1,0 +1,29 @@
+import 'package:turf/turf.dart';
+
+class AssignedElement {
+  final TeamAssignmentStatus status;
+  final String name;
+  final TeamAssignmentType type;
+  final AssignedElementType elementType;
+  final DateTime assignmentDate;
+  final String assignee;
+  final DateTime? closedDate;
+  final GeometryObject coords;
+
+  AssignedElement({
+    required this.status,
+    required this.name,
+    required this.type,
+    required this.elementType,
+    required this.assignmentDate,
+    required this.assignee,
+    required this.coords,
+    this.closedDate,
+  });
+}
+
+enum AssignedElementType { route, area }
+
+enum TeamAssignmentStatus { closed, open }
+
+enum TeamAssignmentType { door, flyer, poster }

--- a/lib/features/campaigns/screens/teams/team_assigned_elements.dart
+++ b/lib/features/campaigns/screens/teams/team_assigned_elements.dart
@@ -1,7 +1,10 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Route;
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/services/converters.dart';
+import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/features/campaigns/models/team/team_assignment.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart' hide Image;
 import 'package:intl/intl.dart';
@@ -32,119 +35,15 @@ class _TeamAssignedElementsState extends State<TeamAssignedElements> {
   Future<void> _loadData() async {
     setState(() => _loading = true);
 
-    // await Future.delayed(Duration(seconds: 1));
-
-    // TODO #736 remove mock data when getOwnTeam and getAssignedData is working
-    await Future<void>.delayed(Duration(milliseconds: 250));
-    // var teamsService = GetIt.I<GrueneApiTeamsService>();
-    // var team = await teamsService.getAssignedElements(widget.currentTeam.id);
-    var assignedElements = [
-      AssignedElement(
-        name: 'Haustür-Route 8838',
-        type: TeamAssignmentType.door,
-        status: TeamAssignmentStatus.open,
-        elementType: ElementType.route,
-        coords: turf.LineString(coordinates: [turf.Position(0, 0), turf.Position(1, 1)]),
-        assignmentDate: DateTime(2025, 9, 12),
-        assignee: 'Renate S.',
-      ),
-      AssignedElement(
-        name: 'von Kotti bis U-Schönlein',
-        type: TeamAssignmentType.poster,
-        status: TeamAssignmentStatus.open,
-        elementType: ElementType.route,
-        coords: turf.LineString(coordinates: [turf.Position(10, 10), turf.Position(11, 11)]),
-        assignmentDate: DateTime(2025, 9, 11),
-        assignee: 'Paul W.',
-      ),
-      AssignedElement(
-        name: 'Plakat-Route 11223',
-        type: TeamAssignmentType.poster,
-        status: TeamAssignmentStatus.open,
-        elementType: ElementType.route,
-        coords: turf.LineString(coordinates: [turf.Position(20, 20), turf.Position(21, 21)]),
-        assignmentDate: DateTime(2025, 9, 10),
-        assignee: 'Renate S.',
-      ),
-      AssignedElement(
-        name: 'U Warschauer flyern',
-        type: TeamAssignmentType.flyer,
-        status: TeamAssignmentStatus.open,
-        elementType: ElementType.area,
-        coords: turf.Polygon(
-          coordinates: [
-            [turf.Position(0, 0), turf.Position(0, 1), turf.Position(1, 1), turf.Position(1, 0), turf.Position(0, 0)],
-          ],
-        ),
-        assignmentDate: DateTime(2025, 9, 9),
-        assignee: 'Anne M.',
-      ),
-      AssignedElement(
-        name: 'V Klimtstraße',
-        type: TeamAssignmentType.flyer,
-        status: TeamAssignmentStatus.closed,
-        elementType: ElementType.area,
-        coords: turf.Polygon(
-          coordinates: [
-            [
-              turf.Position(10, 10),
-              turf.Position(10, 11),
-              turf.Position(11, 11),
-              turf.Position(11, 10),
-              turf.Position(10, 10),
-            ],
-          ],
-        ),
-        assignmentDate: DateTime(2024, 8, 15),
-        assignee: 'Max K.',
-        closedDate: DateTime(2025, 1, 20),
-      ),
-      AssignedElement(
-        name: 'Schönbrunner Strasse',
-        type: TeamAssignmentType.flyer,
-        status: TeamAssignmentStatus.closed,
-        elementType: ElementType.area,
-        coords: turf.Polygon(
-          coordinates: [
-            [
-              turf.Position(20, 20),
-              turf.Position(20, 21),
-              turf.Position(21, 21),
-              turf.Position(21, 20),
-              turf.Position(20, 20),
-            ],
-          ],
-        ),
-        assignmentDate: DateTime(2023, 3, 20),
-        assignee: 'Lisa T.',
-        closedDate: DateTime(2025, 1, 10),
-      ),
-      AssignedElement(
-        name: 'Neuwaldegger Platz',
-        type: TeamAssignmentType.flyer,
-        status: TeamAssignmentStatus.closed,
-        elementType: ElementType.area,
-        coords: turf.Polygon(
-          coordinates: [
-            [
-              turf.Position(30, 30),
-              turf.Position(30, 31),
-              turf.Position(31, 31),
-              turf.Position(31, 30),
-              turf.Position(30, 30),
-            ],
-          ],
-        ),
-        assignmentDate: DateTime(2026, 6, 5),
-        assignee: 'John D.',
-        closedDate: DateTime(2025, 1, 1),
-      ),
-    ];
-    assignedElements.shuffle();
+    var teamsService = GetIt.I<GrueneApiTeamsService>();
+    var assignedElements = await teamsService.getTeamAssignments(teamId: widget.currentTeam.id);
 
     setState(() {
       _loading = false;
-      _assignedElements = assignedElements;
+      _assignedElements = [
+        ...assignedElements.routes.map((r) => r.asAssignedElement()),
+        ...assignedElements.areas.map((a) => a.asAssignedElement()),
+      ];
     });
   }
 
@@ -263,7 +162,7 @@ class _TeamAssignedElementsState extends State<TeamAssignedElements> {
       assignee: assignedElement.assignee,
     );
     var formatter = NumberFormat.decimalPatternDigits(locale: t.$meta.locale.languageCode, decimalDigits: 1);
-    if (assignedElement.elementType == ElementType.area) {
+    if (assignedElement.elementType == AssignedElementType.area) {
       var areaData = turf.area(assignedElement.coords)! / 1000 / 1000;
       var areaInfo = t.campaigns.team.team_assigned_elements_area_info(area: formatter.format(areaData));
       return '$areaInfo | $assignmentInfo';
@@ -283,31 +182,3 @@ class _TeamAssignedElementsState extends State<TeamAssignedElements> {
         : a.closedDate!.compareTo(b.closedDate!) * -1;
   }
 }
-
-class AssignedElement {
-  final TeamAssignmentStatus status;
-  final String name;
-  final TeamAssignmentType type;
-  final ElementType elementType;
-  final turf.GeometryObject coords;
-  final DateTime assignmentDate;
-  final String assignee;
-  final DateTime? closedDate;
-
-  AssignedElement({
-    required this.status,
-    required this.name,
-    required this.type,
-    required this.elementType,
-    required this.coords,
-    required this.assignmentDate,
-    required this.assignee,
-    this.closedDate,
-  });
-}
-
-enum ElementType { route, area }
-
-enum TeamAssignmentStatus { closed, open }
-
-enum TeamAssignmentType { door, flyer, poster }

--- a/lib/features/campaigns/screens/teams/team_home.dart
+++ b/lib/features/campaigns/screens/teams/team_home.dart
@@ -7,7 +7,7 @@ import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/features/campaigns/screens/mixins.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/open_invitation_list.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/profile_visibility_hint.dart';
-// import 'package:gruene_app/features/campaigns/screens/teams/team_assigned_elements.dart';
+import 'package:gruene_app/features/campaigns/screens/teams/team_assigned_elements.dart';
 // import 'package:gruene_app/features/campaigns/screens/teams/team_member_statistics.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/team_profile.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
@@ -94,8 +94,8 @@ class _TeamHomeState extends State<TeamHome> with ConfirmDelete {
       currentUser: widget.currentUser,
       reloadTeam: (team) => _loadData(preloadedProfile: _currentProfile, preloadedTeam: team),
     );
+    yield TeamAssignedElements(currentTeam: _currentTeam!);
     // TODO features not ready yet - disable them for now
-    // yield TeamAssignedElements(currentTeam: _currentTeam!);
     // yield TeamMemberStatistics(currentTeam: _currentTeam!);
     yield GestureDetector(
       onTap: _leaveTeam,

--- a/swaggers/gruene-api.yaml
+++ b/swaggers/gruene-api.yaml
@@ -2421,6 +2421,35 @@ paths:
       summary: Update own team information
       tags:
         - campaigns
+  /v1/campaigns/teams/{teamId}/assignments:
+    get:
+      operationId: getTeamAssignments
+      parameters:
+        - name: campaignId
+          required: false
+          in: query
+          description: Filter data output by campaign ids
+          schema:
+            type: string
+        - name: teamId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamAssignmentResponse'
+        '401':
+          description: ''
+      security:
+        - bearer: []
+      summary: Get Team assignments
+      tags:
+        - campaigns
   /v1/news:
     get:
       operationId: findNews
@@ -4559,6 +4588,13 @@ components:
           $ref: '#/components/schemas/AreaHouse'
         polygon:
           $ref: '#/components/schemas/Polygon'
+        assignedBy:
+          type: string
+          nullable: true
+        assignedAt:
+          format: date-time
+          type: string
+          nullable: true
         team:
           nullable: true
           allOf:
@@ -5670,6 +5706,113 @@ components:
         - total
         - offset
         - limit
+    AreaAssignment:
+      type: object
+      properties:
+        assigningUser:
+          type: string
+        id:
+          type: string
+          example: '1'
+        type:
+          type: string
+          enum:
+            - FLYER_SPOT
+            - POSTER
+            - HOUSE
+        status:
+          type: string
+          enum:
+            - OPEN
+            - ASSIGNED
+            - CLOSED
+        campaignId:
+          type: string
+        createdAt:
+          format: date-time
+          type: string
+        comment:
+          type: string
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        polygon:
+          $ref: '#/components/schemas/Polygon'
+        assignedBy:
+          type: string
+          nullable: true
+        assignedAt:
+          format: date-time
+          type: string
+          nullable: true
+      required:
+        - assigningUser
+        - id
+        - type
+        - status
+        - campaignId
+        - createdAt
+        - comment
+        - name
+        - polygon
+    RouteAssignment:
+      type: object
+      properties:
+        assigningUser:
+          type: string
+        id:
+          type: string
+          example: '1'
+        type:
+          type: string
+          enum:
+            - FLYER_SPOT
+            - POSTER
+            - HOUSE
+        campaignId:
+          type: string
+        createdAt:
+          format: date-time
+          type: string
+        status:
+          type: string
+          enum:
+            - OPEN
+            - ASSIGNED
+            - CLOSED
+        name:
+          type: string
+          nullable: true
+        lineString:
+          $ref: '#/components/schemas/LineString'
+        assignedAt:
+          format: date-time
+          type: string
+          nullable: true
+      required:
+        - assigningUser
+        - id
+        - type
+        - campaignId
+        - createdAt
+        - status
+        - name
+        - lineString
+    TeamAssignmentResponse:
+      type: object
+      properties:
+        areas:
+          type: array
+          items:
+            $ref: '#/components/schemas/AreaAssignment'
+        routes:
+          type: array
+          items:
+            $ref: '#/components/schemas/RouteAssignment'
+      required:
+        - areas
+        - routes
     NewsCategory:
       type: object
       properties:


### PR DESCRIPTION

### Short Description

- assigned routes + areas are parsed as assignedElement
- activate previously deactivated widget
<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---