### PR TITLE
896: remove dialog message before showing profile visibility settings

### DIFF
--- a/lib/app/utils/profile_feature_checker.dart
+++ b/lib/app/utils/profile_feature_checker.dart
@@ -76,7 +76,10 @@ class ProfileFeatureChecker {
           ),
           actions: [
             TextButton(
-              onPressed: () => _showProfileVisibilitySettings(context, currentProfile),
+              onPressed: () {
+                Navigator.pop(context);
+                _showProfileVisibilitySettings(context, currentProfile);
+              },
               child: Text(
                 t.common.actions.consent,
                 style: theme.textTheme.labelLarge?.apply(color: theme.colorScheme.secondary),


### PR DESCRIPTION
### Short Description

dialog was not properly removed/closed and therefore shown "forever"
<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #896

---