### PR TITLE
905: only show 'assign team'-function when user has permissions

### DIFF
--- a/lib/features/campaigns/screens/action_area_detail.dart
+++ b/lib/features/campaigns/screens/action_area_detail.dart
@@ -118,32 +118,33 @@ class _ActionAreaDetailState extends State<ActionAreaDetail> {
             ),
           ),
           Container(height: 1, color: ThemeColors.grey100),
-
-          Container(
-            padding: EdgeInsets.symmetric(horizontal: 20, vertical: 4),
-            decoration: BoxDecoration(
-              border: Border(bottom: BorderSide(width: 0.5, color: ThemeColors.textLight)),
-            ),
-            child: Row(
-              children: [
-                SizedBox(width: 6),
-                Icon(Icons.group_outlined, size: 30),
-                SizedBox(width: 35),
-                Expanded(
-                  child: GestureDetector(
-                    onTap: () => (_currentUserInfo.isCampaignManager() && _currentUserKV != null)
-                        ? _selectTeam(_currentActionAreaDetail)
-                        : null,
-                    child: Text(
-                      _currentActionAreaDetail.team?.name ?? t.campaigns.route.quick_action_assign_team,
-                      style: theme.textTheme.bodyLarge,
-                      softWrap: true,
-                    ),
+          ((!_currentUserInfo.isCampaignManager() || _currentUserKV == null) && _currentActionAreaDetail.team == null)
+              ? SizedBox.shrink()
+              : Container(
+                  padding: EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+                  decoration: BoxDecoration(
+                    border: Border(bottom: BorderSide(width: 0.5, color: ThemeColors.textLight)),
+                  ),
+                  child: Row(
+                    children: [
+                      SizedBox(width: 6),
+                      Icon(Icons.group_outlined, size: 30),
+                      SizedBox(width: 35),
+                      Expanded(
+                        child: GestureDetector(
+                          onTap: () => (_currentUserInfo.isCampaignManager() && _currentUserKV != null)
+                              ? _selectTeam(_currentActionAreaDetail)
+                              : null,
+                          child: Text(
+                            _currentActionAreaDetail.team?.name ?? t.campaigns.route.quick_action_assign_team,
+                            style: theme.textTheme.bodyLarge,
+                            softWrap: true,
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-              ],
-            ),
-          ),
 
           Container(
             padding: EdgeInsets.symmetric(horizontal: 20),

--- a/lib/features/campaigns/screens/route_detail.dart
+++ b/lib/features/campaigns/screens/route_detail.dart
@@ -128,32 +128,33 @@ class _RouteDetailState extends State<RouteDetail> {
               ),
             ),
           ),
-
-          Container(
-            padding: EdgeInsets.symmetric(horizontal: 20, vertical: 4),
-            decoration: BoxDecoration(
-              border: Border(bottom: BorderSide(width: 0.5, color: ThemeColors.textLight)),
-            ),
-            child: Row(
-              children: [
-                SizedBox(width: 6),
-                Icon(Icons.group_outlined, size: 30),
-                SizedBox(width: 35),
-                Expanded(
-                  child: GestureDetector(
-                    onTap: () => (_currentUserInfo.isCampaignManager() && _currentUserKV != null)
-                        ? _selectTeam(_currentRouteDetail)
-                        : null,
-                    child: Text(
-                      _currentRouteDetail.team?.name ?? t.campaigns.route.quick_action_assign_team,
-                      style: theme.textTheme.bodyLarge,
-                      softWrap: true,
-                    ),
+          ((!_currentUserInfo.isCampaignManager() || _currentUserKV == null) && _currentRouteDetail.team == null)
+              ? SizedBox.shrink()
+              : Container(
+                  padding: EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+                  decoration: BoxDecoration(
+                    border: Border(bottom: BorderSide(width: 0.5, color: ThemeColors.textLight)),
+                  ),
+                  child: Row(
+                    children: [
+                      SizedBox(width: 6),
+                      Icon(Icons.group_outlined, size: 30),
+                      SizedBox(width: 35),
+                      Expanded(
+                        child: GestureDetector(
+                          onTap: () => (_currentUserInfo.isCampaignManager() && _currentUserKV != null)
+                              ? _selectTeam(_currentRouteDetail)
+                              : null,
+                          child: Text(
+                            _currentRouteDetail.team?.name ?? t.campaigns.route.quick_action_assign_team,
+                            style: theme.textTheme.bodyLarge,
+                            softWrap: true,
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-              ],
-            ),
-          ),
 
           Container(
             padding: EdgeInsets.symmetric(horizontal: 20),


### PR DESCRIPTION
### Short Description
The functionality should not just be disabled, but not shown when user has no permissions to do the function
<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #905

---