### PR TITLE
911: reload on team notification

### DIFF
--- a/lib/app/services/gruene_api_user_service.dart
+++ b/lib/app/services/gruene_api_user_service.dart
@@ -6,7 +6,7 @@ import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 class GrueneApiUserService extends GrueneApiBaseService {
   Future<User> getSelf() async => getFromApi(apiRequest: (api) => api.v1UsersSelfGet());
   Future<UserRbacStructure> getOwnRbac() async => getFromApi(apiRequest: (api) => api.v1UsersSelfRbacStructureGet());
-  Future<UserRbacStructure> addDeviceToken(String deviceToken) async {
+  Future<void> addDeviceToken(String deviceToken) async {
     var platform = Platform.isAndroid
         ? AddDeviceTokenPlatform.android
         : (Platform.isIOS ? AddDeviceTokenPlatform.ios : AddDeviceTokenPlatform.swaggerGeneratedUnknown);

--- a/lib/app/services/push_notification_handlers/notification_handlers.dart
+++ b/lib/app/services/push_notification_handlers/notification_handlers.dart
@@ -1,8 +1,10 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:gruene_app/app/constants/route_locations.dart';
+import 'package:gruene_app/features/campaigns/controllers/team_refresh_controller.dart';
 
 part 'base_notification_handler.dart';
 part 'news_notification_handler.dart';

--- a/lib/app/services/push_notification_handlers/team_notification_handler.dart
+++ b/lib/app/services/push_notification_handlers/team_notification_handler.dart
@@ -5,6 +5,7 @@ class TeamNotificationHandler extends BaseNotificationHandler {
   void processMessage(RemoteMessage message, BuildContext? context) {
     var routerLocation = RouteLocations.getRoute([RouteLocations.campaigns, RouteLocations.campaignTeamDetail]);
     _navigateTo(context, routerLocation);
+    GetIt.I<TeamRefreshController>().reload();
   }
 
   @override
@@ -15,5 +16,6 @@ class TeamNotificationHandler extends BaseNotificationHandler {
   @override
   void processPayload(NotificationResponse response, BuildContext? context) {
     _navigateTo(context, RouteLocations.getRoute([RouteLocations.campaigns, RouteLocations.campaignTeamDetail]));
+    GetIt.I<TeamRefreshController>().reload();
   }
 }

--- a/lib/features/campaigns/controllers/team_refresh_controller.dart
+++ b/lib/features/campaigns/controllers/team_refresh_controller.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+class TeamRefreshController extends ChangeNotifier {
+  void reload() {
+    notifyListeners();
+  }
+}

--- a/lib/features/campaigns/screens/teams/new_team_mixin.dart
+++ b/lib/features/campaigns/screens/teams/new_team_mixin.dart
@@ -1,5 +1,8 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:gruene_app/app/constants/design_constants.dart';
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_base_service.dart';
 import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
@@ -127,7 +130,7 @@ mixin NewTeamMixin {
     return await showModalBottomSheet<U>(
       context: context,
       builder: (context) => Padding(
-        padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+        padding: EdgeInsets.only(bottom: max(MediaQuery.of(context).viewInsets.bottom, DesignConstants.bottomPadding)),
         child: child,
       ),
       isScrollControlled: true,

--- a/lib/features/campaigns/screens/teams/new_team_select_team_lead_widget.dart
+++ b/lib/features/campaigns/screens/teams/new_team_select_team_lead_widget.dart
@@ -19,7 +19,7 @@ class NewTeamSelectTeamLeadWidget extends StatefulWidget {
 }
 
 class _NewTeamSelectTeamLeadWidgetState extends State<NewTeamSelectTeamLeadWidget> {
-  late PublicProfile? currentTeamLeadProfile;
+  PublicProfile? currentTeamLeadProfile;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/campaigns/screens/teams/team_home.dart
+++ b/lib/features/campaigns/screens/teams/team_home.dart
@@ -4,6 +4,7 @@ import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_profile_service.dart';
 import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/features/campaigns/controllers/team_refresh_controller.dart';
 import 'package:gruene_app/features/campaigns/screens/mixins.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/open_invitation_list.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/profile_visibility_hint.dart';
@@ -27,13 +28,21 @@ class _TeamHomeState extends State<TeamHome> with ConfirmDelete {
 
   late Team? _currentTeam;
   late Profile? _currentProfile;
+  final TeamRefreshController _teamController = GetIt.I<TeamRefreshController>();
 
   @override
   void initState() {
     super.initState();
+    _teamController.addListener(_onReload);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadData();
     });
+  }
+
+  @override
+  void dispose() {
+    _teamController.removeListener(_onReload);
+    super.dispose();
   }
 
   void _loadData({Team? preloadedTeam, Profile? preloadedProfile}) async {
@@ -174,5 +183,9 @@ class _TeamHomeState extends State<TeamHome> with ConfirmDelete {
       confirmationDialogText: t.campaigns.team.archive_team_confirmation_dialog,
       actionTitle: t.common.actions.confirm,
     );
+  }
+
+  void _onReload() {
+    _loadData();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,6 +38,7 @@ import 'package:gruene_app/app/utils/app_settings.dart';
 import 'package:gruene_app/app/utils/profile_feature_checker.dart';
 import 'package:gruene_app/app/widgets/clean_layout.dart';
 import 'package:gruene_app/features/campaigns/controllers/map_screen_controller.dart';
+import 'package:gruene_app/features/campaigns/controllers/team_refresh_controller.dart';
 import 'package:gruene_app/features/campaigns/helper/campaign_action_cache.dart';
 import 'package:gruene_app/features/campaigns/helper/campaign_action_cache_timer.dart';
 import 'package:gruene_app/features/campaigns/helper/file_cache_manager.dart';
@@ -97,6 +98,7 @@ Future<void> main() async {
   GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.poster.toString());
   GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.flyer.toString());
   GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.door.toString());
+  GetIt.I.registerSingleton<TeamRefreshController>(TeamRefreshController());
   GetIt.I.registerFactory<GrueneApiPosterService>(() => GrueneApiPosterService());
   GetIt.I.registerFactory<GrueneApiDoorService>(() => GrueneApiDoorService());
   GetIt.I.registerFactory<GrueneApiFlyerService>(() => GrueneApiFlyerService());


### PR DESCRIPTION
### Short Description
When tapping a team notification, the team tab should reload when already loaded before

<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #911

---