### PR TITLE
895: show hint on team screen when no-team

### DIFF
--- a/lib/app/theme/theme.dart
+++ b/lib/app/theme/theme.dart
@@ -14,6 +14,9 @@ class ThemeColors {
   // Very Light Green (#F3FAF6)
   static const Color grey100 = Color(0xFFF3FAF6);
 
+  // Light Green (#E6ECEA)
+  static const Color grey200 = Color(0xFFE6ECEA);
+
   // White (#FFFFFF)
   static const Color background = Color(0xFFFFFFFF);
 

--- a/lib/features/campaigns/screens/teams/open_invitation_list.dart
+++ b/lib/features/campaigns/screens/teams/open_invitation_list.dart
@@ -11,8 +11,14 @@ import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 class OpenInvitationList extends StatefulWidget {
   final void Function() reload;
   final Team? currentTeam;
+  final void Function(bool value) hasInvitationsCallback;
 
-  const OpenInvitationList({super.key, required this.reload, required this.currentTeam});
+  const OpenInvitationList({
+    super.key,
+    required this.reload,
+    required this.currentTeam,
+    required this.hasInvitationsCallback,
+  });
 
   @override
   State<OpenInvitationList> createState() => _OpenInvitationListState();
@@ -39,6 +45,7 @@ class _OpenInvitationListState extends State<OpenInvitationList> {
     setState(() {
       _loading = false;
       _openInvitations = openInvitations;
+      widget.hasInvitationsCallback(_openInvitations.isNotEmpty);
     });
   }
 

--- a/lib/features/campaigns/screens/teams/team_home.dart
+++ b/lib/features/campaigns/screens/teams/team_home.dart
@@ -30,6 +30,8 @@ class _TeamHomeState extends State<TeamHome> with ConfirmDelete {
   late Profile? _currentProfile;
   final TeamRefreshController _teamController = GetIt.I<TeamRefreshController>();
 
+  var _hasInvitations = true;
+
   @override
   void initState() {
     super.initState();
@@ -85,15 +87,39 @@ class _TeamHomeState extends State<TeamHome> with ConfirmDelete {
     subItems.add(
       OpenInvitationList(
         reload: () => _loadData(preloadedProfile: _currentProfile),
+        hasInvitationsCallback: (bool value) => setState(() => _hasInvitations = value),
         currentTeam: _currentTeam,
       ),
     );
 
     if (_currentTeam != null) {
       subItems.addAll(_getTeamWidgets(context));
+    } else {
+      subItems.add(_getNoTeamHint());
     }
 
     return Column(children: [...subItems]);
+  }
+
+  Offstage _getNoTeamHint() {
+    var theme = Theme.of(context);
+    return Offstage(
+      offstage: _hasInvitations,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+        child: Column(
+          children: [
+            Center(child: Icon(Icons.groups_outlined, color: ThemeColors.grey200, size: 64)),
+            Text(
+              widget.currentUser.isCampaignManager()
+                  ? t.campaigns.team.no_team_yet_hint_privileged
+                  : t.campaigns.team.no_team_yet_hint,
+              style: theme.textTheme.labelLarge,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   Iterable<Widget> _getTeamWidgets(BuildContext context) sync* {

--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -283,6 +283,8 @@
       "cancel_invitation": "Einladung zurückziehen",
       "add_team_member": "Teammitglied hinzufügen",
       "profile_visibility_hint": "Dein Profil hat nur eine eingeschränkte Sichtbarkeit. Der Team Modus erfordert, dass dein Profil mindestens im Kreisverband [KV] auffindbar sein muss, damit du zu Teams hinzugefügt werden kannst.\nBitte setze eine entsprechende Sichtbarkeitseinstellung.",
+      "no_team_yet_hint": "Du bist momentan in keinem Team Mitglied. Bitte eine*n Lokalkoordinator*in deiner Gliederung, dich in ein Team einzuladen.",
+      "no_team_yet_hint_privileged": "Du bist momentan in keinem Team Mitglied. Du kannst von Lokalkoordinator*innen in ein Team eingeladen werden oder selbst ein neues Team anlegen.",
       "invitations": {
         "open_invitations_label": "Offene Einladungen",
         "open_invitations_description": {


### PR DESCRIPTION
### Short Description

When user has no team and no open invitation we show a hint what is to be expected on the screen
<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #895

---