### PR TITLE
928: truncate to scroll for route/area names in assignment list

### DIFF
--- a/lib/features/campaigns/screens/teams/team_assigned_elements.dart
+++ b/lib/features/campaigns/screens/teams/team_assigned_elements.dart
@@ -127,7 +127,13 @@ class _TeamAssignedElementsState extends State<TeamAssignedElements> {
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(assignedElement.name, style: theme.textTheme.titleMedium),
+              Container(
+                constraints: BoxConstraints(maxWidth: MediaQuery.sizeOf(context).width - 90),
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Text(assignedElement.name, style: theme.textTheme.titleMedium),
+                ),
+              ),
               Text(
                 _getAssignmentInfoText(assignedElement),
                 style: theme.textTheme.labelSmall?.apply(color: ThemeColors.textDisabled),


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
We bind the name of routes/areas to a container with some constraints to then put this in SingleChildScrollWidget. Allows user to scroll name and it's truncated.

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #928

---