### PR TITLE
945: apply visuals for badge_statistics_detail

### DIFF
--- a/lib/features/campaigns/screens/badge_statistics_detail.dart
+++ b/lib/features/campaigns/screens/badge_statistics_detail.dart
@@ -13,28 +13,27 @@ class BadgeStatisticsDetail extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Container(
-      padding: EdgeInsets.all(16),
-      color: theme.colorScheme.surfaceDim,
-      child: Column(children: [_getBadgeBox(poiStatistics, context, theme)]),
+      padding: EdgeInsets.all(12),
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Row(
+              children: [Text(t.campaigns.statistic.poi_statistics.my_badges, style: theme.textTheme.titleMedium)],
+            ),
+          ),
+          _getBadgeBox(poiStatistics, context, theme),
+        ],
+      ),
     );
   }
 
   Widget _getBadgeBox(CampaignStatisticsModel statistics, BuildContext context, ThemeData theme) {
-    var mediaQuery = MediaQuery.of(context);
     return Container(
-      padding: EdgeInsets.all(16),
-      width: mediaQuery.size.width,
-      decoration: BoxDecoration(
-        color: ThemeColors.background,
-        borderRadius: BorderRadius.circular(19),
-        boxShadow: [BoxShadow(color: ThemeColors.textDark.withAlpha(10), offset: Offset(2, 4))],
-      ),
+      padding: EdgeInsets.only(bottom: 16, left: 12, right: 12),
+      decoration: boxShadowDecoration,
       child: Column(
         children: [
-          Align(
-            alignment: Alignment.centerLeft,
-            child: Text(t.campaigns.statistic.poi_statistics.my_badges, style: theme.textTheme.titleMedium),
-          ),
           Align(
             alignment: Alignment.centerLeft,
             child: Text(


### PR DESCRIPTION
### Short Description

Visuals were not yet defined to be applied to the badge part of the statistics
<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #945

---