### PR TITLE
958: switch to ellipsis for overflow

### DIFF
--- a/lib/features/campaigns/screens/team_statistics_category_detail.dart
+++ b/lib/features/campaigns/screens/team_statistics_category_detail.dart
@@ -152,12 +152,10 @@ class _TeamStatisticsCategoryDetailState extends State<TeamStatisticsCategoryDet
                   children: [
                     Container(
                       constraints: BoxConstraints(maxWidth: MediaQuery.sizeOf(context).width - 165),
-                      child: SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        child: Text(
-                          item.teamName,
-                          style: theme.textTheme.labelLarge?.apply(color: ThemeColors.textDark),
-                        ),
+                      child: Text(
+                        item.teamName,
+                        style: theme.textTheme.labelLarge?.apply(color: ThemeColors.textDark),
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
                     Text(
@@ -197,6 +195,9 @@ class _TeamStatisticsCategoryDetailState extends State<TeamStatisticsCategoryDet
       ),
     );
 
+    if (item.teamMemberCount > 0) {
+      memberItemWidget.disable();
+    }
     return memberItemWidget;
   }
 

--- a/lib/features/campaigns/screens/teams/team_assigned_elements.dart
+++ b/lib/features/campaigns/screens/teams/team_assigned_elements.dart
@@ -129,10 +129,7 @@ class _TeamAssignedElementsState extends State<TeamAssignedElements> {
             children: [
               Container(
                 constraints: BoxConstraints(maxWidth: MediaQuery.sizeOf(context).width - 90),
-                child: SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  child: Text(assignedElement.name, style: theme.textTheme.titleMedium),
-                ),
+                child: Text(assignedElement.name, style: theme.textTheme.titleMedium, overflow: TextOverflow.ellipsis),
               ),
               Text(
                 _getAssignmentInfoText(assignedElement),
@@ -144,12 +141,7 @@ class _TeamAssignedElementsState extends State<TeamAssignedElements> {
       ),
     );
     if (assignedElement.status == TeamAssignmentStatus.closed) {
-      item = Stack(
-        children: [
-          item,
-          Positioned.fill(child: Container(color: ThemeColors.disabledShadow.withAlpha(170))),
-        ],
-      );
+      item = item.disable();
     }
     return InkWell(onTap: () => _switchToMap(assignedElement), child: item);
   }


### PR DESCRIPTION
### Short Description

We have built sth to pan text when it's too long, but this breaks when we have disabled items as these are done with a semi-transparent overlay. Therefore we switch to text ellipsis for text overflow.

<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #958

---