### PR TITLE
966: use division shortName consistently

### DIFF
--- a/lib/features/campaigns/helper/division_search_helper.dart
+++ b/lib/features/campaigns/helper/division_search_helper.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/services/gruene_api_divisions_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
-import 'package:gruene_app/app/utils/divisions.dart';
 import 'package:gruene_app/features/campaigns/helper/paging_helper.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/search_screen.dart';
 import 'package:gruene_app/features/campaigns/widgets/app_route.dart';

--- a/lib/features/campaigns/helper/profile_search_helper.dart
+++ b/lib/features/campaigns/helper/profile_search_helper.dart
@@ -3,7 +3,6 @@ import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_profile_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
-import 'package:gruene_app/app/utils/divisions.dart';
 import 'package:gruene_app/features/campaigns/helper/paging_helper.dart';
 import 'package:gruene_app/features/campaigns/helper/search_action_state.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/search_screen.dart';

--- a/lib/features/campaigns/screens/teams/new_team_select_division_widget.dart
+++ b/lib/features/campaigns/screens/teams/new_team_select_division_widget.dart
@@ -5,7 +5,6 @@ import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_profile_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
-import 'package:gruene_app/app/utils/divisions.dart';
 import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/features/campaigns/helper/division_search_helper.dart';
 import 'package:gruene_app/features/campaigns/models/team/new_team_details.dart';

--- a/lib/features/campaigns/screens/teams/open_invitation_list.dart
+++ b/lib/features/campaigns/screens/teams/open_invitation_list.dart
@@ -3,7 +3,6 @@ import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
-import 'package:gruene_app/app/utils/divisions.dart';
 import 'package:gruene_app/features/campaigns/helper/app_timers.dart';
 import 'package:gruene_app/features/campaigns/helper/team_helper.dart';
 import 'package:gruene_app/i18n/translations.g.dart';

--- a/lib/features/campaigns/screens/teams/team_profile.dart
+++ b/lib/features/campaigns/screens/teams/team_profile.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:gruene_app/app/constants/design_constants.dart';
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/theme/theme.dart';
-import 'package:gruene_app/app/utils/divisions.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/edit_team_basic_info_widget.dart';
 import 'package:gruene_app/features/campaigns/screens/teams/edit_team_members_widget.dart';
 import 'package:gruene_app/i18n/translations.g.dart';


### PR DESCRIPTION
### Short Description

The sometimes used function shortDisplayName for divisions may result in a view for a user which may not be very consistent. The field shortName is coming from the data itself and should reflect this better and makes our app data-driven.

<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---