### PR TITLE
924 use new status endpoint for routes and areas

### DIFF
--- a/lib/app/services/converters.dart
+++ b/lib/app/services/converters.dart
@@ -20,7 +20,7 @@ import 'package:gruene_app/features/campaigns/helper/campaign_action.dart';
 import 'package:gruene_app/features/campaigns/helper/campaign_constants.dart';
 import 'package:gruene_app/features/campaigns/models/action_area/action_area_assignment_update_model.dart';
 import 'package:gruene_app/features/campaigns/models/action_area/action_area_detail_model.dart';
-import 'package:gruene_app/features/campaigns/models/action_area/action_area_update_model.dart';
+import 'package:gruene_app/features/campaigns/models/action_area/action_area_status_update_model.dart';
 import 'package:gruene_app/features/campaigns/models/doors/door_create_model.dart';
 import 'package:gruene_app/features/campaigns/models/doors/door_detail_model.dart';
 import 'package:gruene_app/features/campaigns/models/doors/door_update_model.dart';

--- a/lib/app/services/converters.dart
+++ b/lib/app/services/converters.dart
@@ -35,7 +35,7 @@ import 'package:gruene_app/features/campaigns/models/posters/poster_photo_model.
 import 'package:gruene_app/features/campaigns/models/posters/poster_update_model.dart';
 import 'package:gruene_app/features/campaigns/models/route/route_assignment_update_model.dart';
 import 'package:gruene_app/features/campaigns/models/route/route_detail_model.dart';
-import 'package:gruene_app/features/campaigns/models/route/route_update_model.dart';
+import 'package:gruene_app/features/campaigns/models/route/route_status_update_model.dart';
 import 'package:gruene_app/features/campaigns/models/team/new_team_details.dart';
 import 'package:gruene_app/features/campaigns/models/team/team_assignment.dart';
 import 'package:gruene_app/features/campaigns/widgets/enhanced_wheel_slider.dart';

--- a/lib/app/services/converters/action_area_detail_model_parsing.dart
+++ b/lib/app/services/converters/action_area_detail_model_parsing.dart
@@ -1,8 +1,8 @@
 part of '../converters.dart';
 
 extension ActionAreaDetailModelParsing on ActionAreaDetailModel {
-  ActionAreaUpdateModel asActionAreaUpdate() {
-    return ActionAreaUpdateModel(id: id, status: status, actionAreaDetail: this);
+  ActionAreaStatusUpdateModel asActionAreaUpdate() {
+    return ActionAreaStatusUpdateModel(id: id, status: status, actionAreaDetail: this);
   }
 
   ActionAreaAssignmentUpdateModel asActionAreaAssignmentUpdate() {

--- a/lib/app/services/converters/action_area_update_model_parsing.dart
+++ b/lib/app/services/converters/action_area_update_model_parsing.dart
@@ -1,6 +1,6 @@
 part of '../converters.dart';
 
-extension ActionAreaUpdateModelParsing on ActionAreaUpdateModel {
+extension ActionAreaUpdateModelParsing on ActionAreaStatusUpdateModel {
   ActionAreaDetailModel transformToVirtualActionAreaDetailModel() {
     var newActionAreaDetail = actionAreaDetail.copyWith(status: status, isVirtual: true);
     return newActionAreaDetail;

--- a/lib/app/services/converters/area_status_parsing.dart
+++ b/lib/app/services/converters/area_status_parsing.dart
@@ -1,12 +1,12 @@
 part of '../converters.dart';
 
 extension AreaStatusParsing on AreaStatus {
-  api_enums.UpdateAreaStatus asUpdateAreaStatus() {
+  api_enums.UpdateAreaStatusStatus asUpdateAreaStatusStatus() {
     switch (this) {
       case AreaStatus.open:
-        return api_enums.UpdateAreaStatus.open;
+        return api_enums.UpdateAreaStatusStatus.open;
       case AreaStatus.closed:
-        return api_enums.UpdateAreaStatus.closed;
+        return api_enums.UpdateAreaStatusStatus.closed;
       case AreaStatus.swaggerGeneratedUnknown:
         throw UnimplementedError();
     }

--- a/lib/app/services/converters/campaign_action_parsing.dart
+++ b/lib/app/services/converters/campaign_action_parsing.dart
@@ -76,9 +76,9 @@ extension CampaignActionParsing on CampaignAction {
     );
   }
 
-  RouteUpdateModel getAsRouteUpdate() {
+  RouteStatusUpdateModel getAsRouteStatusUpdate() {
     var data = jsonDecode(serialized!) as Map<String, dynamic>;
-    var model = RouteUpdateModel.fromJson(data.updateIdField(poiId!));
+    var model = RouteStatusUpdateModel.fromJson(data.updateIdField(poiId!));
 
     return model;
   }

--- a/lib/app/services/converters/campaign_action_parsing.dart
+++ b/lib/app/services/converters/campaign_action_parsing.dart
@@ -90,9 +90,9 @@ extension CampaignActionParsing on CampaignAction {
     return model;
   }
 
-  ActionAreaUpdateModel getAsActionAreaUpdate() {
+  ActionAreaStatusUpdateModel getAsActionAreaStatusUpdate() {
     var data = jsonDecode(serialized!) as Map<String, dynamic>;
-    var model = ActionAreaUpdateModel.fromJson(data.updateIdField(poiId!));
+    var model = ActionAreaStatusUpdateModel.fromJson(data.updateIdField(poiId!));
 
     return model;
   }

--- a/lib/app/services/converters/poi_service_type_parsing.dart
+++ b/lib/app/services/converters/poi_service_type_parsing.dart
@@ -37,9 +37,8 @@ extension PoiCacheTypeParsing on PoiCacheType {
         return CampaignActionType.editDoor;
       case PoiCacheType.flyer:
         return CampaignActionType.editFlyer;
-      case PoiCacheType.actionArea:
-        return CampaignActionType.editActionArea;
       case PoiCacheType.route:
+      case PoiCacheType.actionArea:
         throw UnimplementedError();
     }
   }

--- a/lib/app/services/converters/route_detail_model_parsing.dart
+++ b/lib/app/services/converters/route_detail_model_parsing.dart
@@ -1,8 +1,8 @@
 part of '../converters.dart';
 
 extension RouteDetailModelParsing on RouteDetailModel {
-  RouteUpdateModel asRouteUpdate() {
-    return RouteUpdateModel(id: id, status: status, routeDetail: this);
+  RouteStatusUpdateModel asRouteStatusUpdate() {
+    return RouteStatusUpdateModel(id: id, status: status, routeDetail: this);
   }
 
   RouteAssignmentUpdateModel asRouteAssignmentUpdate() {

--- a/lib/app/services/converters/route_type_parsing.dart
+++ b/lib/app/services/converters/route_type_parsing.dart
@@ -27,12 +27,12 @@ extension TeamRouteTypeParsing on RouteType {
 }
 
 extension TeamRouteStatusParsing on RouteStatus {
-  api_enums.UpdateRouteStatus asUpdateRouteStatus() {
+  api_enums.UpdateRouteStatusStatus asUpdateRouteStatusStatus() {
     switch (this) {
       case RouteStatus.open:
-        return api_enums.UpdateRouteStatus.open;
+        return api_enums.UpdateRouteStatusStatus.open;
       case RouteStatus.closed:
-        return api_enums.UpdateRouteStatus.closed;
+        return api_enums.UpdateRouteStatusStatus.closed;
 
       case RouteStatus.swaggerGeneratedUnknown:
         throw UnimplementedError();

--- a/lib/app/services/converters/route_update_model_parsing.dart
+++ b/lib/app/services/converters/route_update_model_parsing.dart
@@ -1,6 +1,6 @@
 part of '../converters.dart';
 
-extension RouteUpdateModelParsing on RouteUpdateModel {
+extension RouteStatusUpdateModelParsing on RouteStatusUpdateModel {
   RouteDetailModel transformToVirtualRouteDetailModel() {
     var newRouteDetail = routeDetail.copyWith(status: status, isVirtual: true);
     return newRouteDetail;

--- a/lib/app/services/gruene_api_action_area_service.dart
+++ b/lib/app/services/gruene_api_action_area_service.dart
@@ -1,7 +1,7 @@
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_base_service.dart';
 import 'package:gruene_app/features/campaigns/models/action_area/action_area_assignment_update_model.dart';
-import 'package:gruene_app/features/campaigns/models/action_area/action_area_update_model.dart';
+import 'package:gruene_app/features/campaigns/models/action_area/action_area_status_update_model.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
 class GrueneApiActionAreaService extends GrueneApiBaseService {
@@ -10,15 +10,10 @@ class GrueneApiActionAreaService extends GrueneApiBaseService {
   Future<Area> getActionArea(String actionAreaId) async =>
       getFromApi(apiRequest: (api) => api.v1CampaignsAreasAreaIdGet(areaId: actionAreaId));
 
-  Future<void> updateActionArea(ActionAreaUpdateModel actionArea) => getFromApi(
-    apiRequest: (api) => api.v1CampaignsAreasAreaIdPut(
+  Future<void> updateActionAreaStatus(ActionAreaStatusUpdateModel actionArea) => getFromApi(
+    apiRequest: (api) => api.v1CampaignsAreasAreaIdStatusPut(
       areaId: actionArea.id,
-      body: UpdateArea(
-        name: actionArea.actionAreaDetail.name,
-        comment: actionArea.actionAreaDetail.comment,
-        status: actionArea.status.asUpdateAreaStatus(),
-        polygon: actionArea.actionAreaDetail.polygon,
-      ),
+      body: UpdateAreaStatus(status: actionArea.status.asUpdateAreaStatusStatus()),
     ),
   );
 

--- a/lib/app/services/gruene_api_route_service.dart
+++ b/lib/app/services/gruene_api_route_service.dart
@@ -1,7 +1,7 @@
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_base_service.dart';
 import 'package:gruene_app/features/campaigns/models/route/route_assignment_update_model.dart';
-import 'package:gruene_app/features/campaigns/models/route/route_update_model.dart';
+import 'package:gruene_app/features/campaigns/models/route/route_status_update_model.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
 class GrueneApiRouteService extends GrueneApiBaseService {
@@ -10,22 +10,17 @@ class GrueneApiRouteService extends GrueneApiBaseService {
   Future<Route> getRoute(String routeId) async =>
       getFromApi(apiRequest: (api) => api.v1CampaignsRoutesRouteIdGet(routeId: routeId));
 
-  Future<void> updateRoute(RouteUpdateModel route) => getFromApi(
-    apiRequest: (api) => api.v1CampaignsRoutesRouteIdPut(
-      routeId: route.id,
-      body: UpdateRoute(
-        name: route.routeDetail.name,
-        type: route.routeDetail.type.asUpdateRouteType(),
-        status: route.status.asUpdateRouteStatus(),
-        lineString: route.routeDetail.lineString,
-      ),
-    ),
-  );
-
   Future<void> updateRouteAssignemnt(RouteAssignmentUpdateModel route) => getFromApi(
     apiRequest: (api) => api.v1CampaignsRoutesRouteIdTeamPut(
       routeId: route.id,
       body: RouteAssignTeam(teamId: route.team?.id),
+    ),
+  );
+
+  Future<void> updateRouteStatus(RouteStatusUpdateModel route) => getFromApi(
+    apiRequest: (api) => api.v1CampaignsRoutesRouteIdStatusPut(
+      routeId: route.id,
+      body: UpdateRouteStatus(status: route.status.asUpdateRouteStatusStatus()),
     ),
   );
 }

--- a/lib/features/campaigns/helper/campaign_action.dart
+++ b/lib/features/campaigns/helper/campaign_action.dart
@@ -91,6 +91,6 @@ enum CampaignActionType {
   deleteFlyer,
   editRouteStatus,
   editRouteAssignment,
-  editActionArea,
+  editActionAreaStatus,
   editActionAreaAssignment,
 }

--- a/lib/features/campaigns/helper/campaign_action.dart
+++ b/lib/features/campaigns/helper/campaign_action.dart
@@ -89,7 +89,7 @@ enum CampaignActionType {
   addFlyer,
   editFlyer,
   deleteFlyer,
-  editRoute,
+  editRouteStatus,
   editRouteAssignment,
   editActionArea,
   editActionAreaAssignment,

--- a/lib/features/campaigns/helper/campaign_action_cache.dart
+++ b/lib/features/campaigns/helper/campaign_action_cache.dart
@@ -17,7 +17,7 @@ import 'package:gruene_app/features/campaigns/helper/campaign_action.dart';
 import 'package:gruene_app/features/campaigns/helper/media_helper.dart';
 import 'package:gruene_app/features/campaigns/models/action_area/action_area_assignment_update_model.dart';
 import 'package:gruene_app/features/campaigns/models/action_area/action_area_detail_model.dart';
-import 'package:gruene_app/features/campaigns/models/action_area/action_area_update_model.dart';
+import 'package:gruene_app/features/campaigns/models/action_area/action_area_status_update_model.dart';
 import 'package:gruene_app/features/campaigns/models/doors/door_create_model.dart';
 import 'package:gruene_app/features/campaigns/models/doors/door_detail_model.dart';
 import 'package:gruene_app/features/campaigns/models/doors/door_update_model.dart';
@@ -178,15 +178,15 @@ class CampaignActionCache extends ChangeNotifier {
           throw ArgumentError('Unknown route update type');
         }
       case PoiCacheType.actionArea:
-        if (poi.runtimeType == ActionAreaUpdateModel) {
-          return await _addUpdateAction<ActionAreaUpdateModel>(
+        if (poi.runtimeType == ActionAreaStatusUpdateModel) {
+          return await _addUpdateAction<ActionAreaStatusUpdateModel>(
             poiType: poiType,
-            poi: poi as ActionAreaUpdateModel,
+            poi: poi as ActionAreaStatusUpdateModel,
             getId: (poi) => poi.id,
             getJson: (poi) => poi.toJson(),
             mergeUpdates: (action, poiUpdate) => poiUpdate,
             getMarker: (poi) => poi.transformToVirtualActionAreaDetailModel().transformToFeatureItem(),
-            getActionType: () => CampaignActionType.editActionArea,
+            getActionType: () => CampaignActionType.editActionAreaStatus,
           );
         } else if (poi.runtimeType == ActionAreaAssignmentUpdateModel) {
           return await _addUpdateAction<ActionAreaAssignmentUpdateModel>(
@@ -291,8 +291,8 @@ class CampaignActionCache extends ChangeNotifier {
           var model = action.getAsRouteAssignmentUpdate();
           markerItems.add(model.transformToVirtualRouteDetailModel().transformToFeatureItem());
 
-        case CampaignActionType.editActionArea:
-          var model = action.getAsActionAreaUpdate();
+        case CampaignActionType.editActionAreaStatus:
+          var model = action.getAsActionAreaStatusUpdate();
           markerItems.add(model.transformToVirtualActionAreaDetailModel().transformToFeatureItem());
         case CampaignActionType.editActionAreaAssignment:
           var model = action.getAsActionAreaAssignmentUpdate();
@@ -328,7 +328,7 @@ class CampaignActionCache extends ChangeNotifier {
         }
       case PoiCacheType.actionArea:
         return [
-          CampaignActionType.editActionArea,
+          CampaignActionType.editActionAreaStatus,
           CampaignActionType.editActionAreaAssignment,
         ].map((a) => a.index).toList();
       case PoiCacheType.route:
@@ -412,7 +412,7 @@ class CampaignActionCache extends ChangeNotifier {
       case CampaignActionType.addFlyer:
       case CampaignActionType.editFlyer:
       case CampaignActionType.deleteFlyer:
-      case CampaignActionType.editActionArea:
+      case CampaignActionType.editActionAreaStatus:
       case CampaignActionType.editActionAreaAssignment:
       case null:
         throw UnimplementedError();
@@ -425,8 +425,8 @@ class CampaignActionCache extends ChangeNotifier {
     switch (action.actionType) {
       case CampaignActionType.editActionAreaAssignment:
         return action.getAsActionAreaAssignmentUpdate().transformToVirtualActionAreaDetailModel();
-      case CampaignActionType.editActionArea:
-        return action.getAsActionAreaUpdate().transformToVirtualActionAreaDetailModel();
+      case CampaignActionType.editActionAreaStatus:
+        return action.getAsActionAreaStatusUpdate().transformToVirtualActionAreaDetailModel();
       case CampaignActionType.unknown:
       case CampaignActionType.addPoster:
       case CampaignActionType.editPoster:
@@ -447,10 +447,10 @@ class CampaignActionCache extends ChangeNotifier {
   Future<ActionAreaDetailModel> getPoiAsActionAreaDetail(String poiId) async {
     var detailModel = await _getPoiDetail<ActionAreaDetailModel>(
       poiId: poiId,
-      addActionFilter: CampaignActionType.editActionArea,
-      editActionFilter: CampaignActionType.editActionArea,
-      transformEditAction: (action) => action.getAsActionAreaUpdate().transformToVirtualActionAreaDetailModel(),
-      transformAddAction: (action) => action.getAsActionAreaUpdate().transformToVirtualActionAreaDetailModel(),
+      addActionFilter: CampaignActionType.editActionAreaStatus,
+      editActionFilter: CampaignActionType.editActionAreaStatus,
+      transformEditAction: (action) => action.getAsActionAreaStatusUpdate().transformToVirtualActionAreaDetailModel(),
+      transformAddAction: (action) => action.getAsActionAreaStatusUpdate().transformToVirtualActionAreaDetailModel(),
     );
     return detailModel;
   }
@@ -562,9 +562,9 @@ class CampaignActionCache extends ChangeNotifier {
               await routeApiService.updateRouteAssignemnt(model);
               campaignActionDatabase.delete(action.id!);
 
-            case CampaignActionType.editActionArea:
-              var model = action.getAsActionAreaUpdate();
-              await areaApiService.updateActionArea(model);
+            case CampaignActionType.editActionAreaStatus:
+              var model = action.getAsActionAreaStatusUpdate();
+              await areaApiService.updateActionAreaStatus(model);
               campaignActionDatabase.delete(action.id!);
 
             case CampaignActionType.editActionAreaAssignment:

--- a/lib/features/campaigns/helper/campaign_action_cache.dart
+++ b/lib/features/campaigns/helper/campaign_action_cache.dart
@@ -31,7 +31,7 @@ import 'package:gruene_app/features/campaigns/models/posters/poster_list_item_mo
 import 'package:gruene_app/features/campaigns/models/posters/poster_update_model.dart';
 import 'package:gruene_app/features/campaigns/models/route/route_assignment_update_model.dart';
 import 'package:gruene_app/features/campaigns/models/route/route_detail_model.dart';
-import 'package:gruene_app/features/campaigns/models/route/route_update_model.dart';
+import 'package:gruene_app/features/campaigns/models/route/route_status_update_model.dart';
 import 'package:gruene_app/features/campaigns/widgets/map_controller_simplified.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 import 'package:turf/turf.dart' as turf;
@@ -154,15 +154,15 @@ class CampaignActionCache extends ChangeNotifier {
           getMarker: (poi) => poi.transformToVirtualPoiDetailModel().transformToFeatureItem(),
         );
       case PoiCacheType.route:
-        if (poi.runtimeType == RouteUpdateModel) {
-          return await _addUpdateAction<RouteUpdateModel>(
+        if (poi.runtimeType == RouteStatusUpdateModel) {
+          return await _addUpdateAction<RouteStatusUpdateModel>(
             poiType: poiType,
-            poi: poi as RouteUpdateModel,
+            poi: poi as RouteStatusUpdateModel,
             getId: (poi) => poi.id,
             getJson: (poi) => poi.toJson(),
             mergeUpdates: (action, poiUpdate) => poiUpdate,
             getMarker: (poi) => poi.transformToVirtualRouteDetailModel().transformToFeatureItem(),
-            getActionType: () => CampaignActionType.editRoute,
+            getActionType: () => CampaignActionType.editRouteStatus,
           );
         } else if (poi.runtimeType == RouteAssignmentUpdateModel) {
           return await _addUpdateAction<RouteAssignmentUpdateModel>(
@@ -284,8 +284,8 @@ class CampaignActionCache extends ChangeNotifier {
           var model = _getDeleteMarker(PoiCacheType.flyer, action.poiId!);
           markerItems.add(model.transformToFeatureItem());
 
-        case CampaignActionType.editRoute:
-          var model = action.getAsRouteUpdate();
+        case CampaignActionType.editRouteStatus:
+          var model = action.getAsRouteStatusUpdate();
           markerItems.add(model.transformToVirtualRouteDetailModel().transformToFeatureItem());
         case CampaignActionType.editRouteAssignment:
           var model = action.getAsRouteAssignmentUpdate();
@@ -332,7 +332,10 @@ class CampaignActionCache extends ChangeNotifier {
           CampaignActionType.editActionAreaAssignment,
         ].map((a) => a.index).toList();
       case PoiCacheType.route:
-        return [CampaignActionType.editRoute, CampaignActionType.editRouteAssignment].map((a) => a.index).toList();
+        return [
+          CampaignActionType.editRouteStatus,
+          CampaignActionType.editRouteAssignment,
+        ].map((a) => a.index).toList();
     }
   }
 
@@ -369,13 +372,13 @@ class CampaignActionCache extends ChangeNotifier {
     return detailModel;
   }
 
-  Future<RouteUpdateModel> getPoiAsRouteDetail(String poiId) async {
-    var detailModel = await _getPoiDetail<RouteUpdateModel>(
+  Future<RouteStatusUpdateModel> getPoiAsRouteDetail(String poiId) async {
+    var detailModel = await _getPoiDetail<RouteStatusUpdateModel>(
       poiId: poiId,
-      addActionFilter: CampaignActionType.editRoute,
-      editActionFilter: CampaignActionType.editRoute,
-      transformEditAction: (action) => action.getAsRouteUpdate(),
-      transformAddAction: (action) => action.getAsRouteUpdate(),
+      addActionFilter: CampaignActionType.editRouteStatus,
+      editActionFilter: CampaignActionType.editRouteStatus,
+      transformEditAction: (action) => action.getAsRouteStatusUpdate(),
+      transformAddAction: (action) => action.getAsRouteStatusUpdate(),
     );
     return detailModel;
   }
@@ -397,8 +400,8 @@ class CampaignActionCache extends ChangeNotifier {
     switch (action.actionType) {
       case CampaignActionType.editRouteAssignment:
         return action.getAsRouteAssignmentUpdate().transformToVirtualRouteDetailModel();
-      case CampaignActionType.editRoute:
-        return action.getAsRouteUpdate().transformToVirtualRouteDetailModel();
+      case CampaignActionType.editRouteStatus:
+        return action.getAsRouteStatusUpdate().transformToVirtualRouteDetailModel();
       case CampaignActionType.unknown:
       case CampaignActionType.addPoster:
       case CampaignActionType.editPoster:
@@ -434,7 +437,7 @@ class CampaignActionCache extends ChangeNotifier {
       case CampaignActionType.addFlyer:
       case CampaignActionType.editFlyer:
       case CampaignActionType.deleteFlyer:
-      case CampaignActionType.editRoute:
+      case CampaignActionType.editRouteStatus:
       case CampaignActionType.editRouteAssignment:
       case null:
         throw UnimplementedError();
@@ -549,9 +552,9 @@ class CampaignActionCache extends ChangeNotifier {
               await flyerApiService.deletePoi(action.poiId!.toString());
               campaignActionDatabase.delete(action.id!);
 
-            case CampaignActionType.editRoute:
-              var model = action.getAsRouteUpdate();
-              await routeApiService.updateRoute(model);
+            case CampaignActionType.editRouteStatus:
+              var model = action.getAsRouteStatusUpdate();
+              await routeApiService.updateRouteStatus(model);
               campaignActionDatabase.delete(action.id!);
 
             case CampaignActionType.editRouteAssignment:

--- a/lib/features/campaigns/models/action_area/action_area_status_update_model.dart
+++ b/lib/features/campaigns/models/action_area/action_area_status_update_model.dart
@@ -3,22 +3,23 @@ import 'package:gruene_app/features/campaigns/models/action_area/action_area_det
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 import 'package:json_annotation/json_annotation.dart';
 
-part 'action_area_update_model.g.dart';
+part 'action_area_status_update_model.g.dart';
 
 @JsonSerializable()
-class ActionAreaUpdateModel {
+class ActionAreaStatusUpdateModel {
   final String id;
   final AreaStatus status;
   final ActionAreaDetailModel actionAreaDetail;
 
-  ActionAreaUpdateModel({required this.id, required this.status, required this.actionAreaDetail});
+  ActionAreaStatusUpdateModel({required this.id, required this.status, required this.actionAreaDetail});
 
-  factory ActionAreaUpdateModel.fromJson(Map<String, dynamic> json) => _$ActionAreaUpdateModelFromJson(json);
+  factory ActionAreaStatusUpdateModel.fromJson(Map<String, dynamic> json) =>
+      _$ActionAreaStatusUpdateModelFromJson(json);
 
-  Map<String, dynamic> toJson() => _$ActionAreaUpdateModelToJson(this);
+  Map<String, dynamic> toJson() => _$ActionAreaStatusUpdateModelToJson(this);
 
-  ActionAreaUpdateModel copyWith({String? id, AreaStatus? status, ActionAreaDetailModel? routeDetail}) {
-    return ActionAreaUpdateModel(
+  ActionAreaStatusUpdateModel copyWith({String? id, AreaStatus? status, ActionAreaDetailModel? routeDetail}) {
+    return ActionAreaStatusUpdateModel(
       id: id ?? this.id,
       status: status ?? this.status,
       actionAreaDetail: routeDetail ?? actionAreaDetail,

--- a/lib/features/campaigns/models/route/route_status_update_model.dart
+++ b/lib/features/campaigns/models/route/route_status_update_model.dart
@@ -3,22 +3,22 @@ import 'package:gruene_app/features/campaigns/models/route/route_detail_model.da
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 import 'package:json_annotation/json_annotation.dart';
 
-part 'route_update_model.g.dart';
+part 'route_status_update_model.g.dart';
 
 @JsonSerializable()
-class RouteUpdateModel {
+class RouteStatusUpdateModel {
   final String id;
   final RouteStatus status;
   final RouteDetailModel routeDetail;
 
-  RouteUpdateModel({required this.id, required this.status, required this.routeDetail});
+  RouteStatusUpdateModel({required this.id, required this.status, required this.routeDetail});
 
-  factory RouteUpdateModel.fromJson(Map<String, dynamic> json) => _$RouteUpdateModelFromJson(json);
+  factory RouteStatusUpdateModel.fromJson(Map<String, dynamic> json) => _$RouteStatusUpdateModelFromJson(json);
 
-  Map<String, dynamic> toJson() => _$RouteUpdateModelToJson(this);
+  Map<String, dynamic> toJson() => _$RouteStatusUpdateModelToJson(this);
 
-  RouteUpdateModel copyWith({String? id, RouteStatus? status, RouteDetailModel? routeDetail}) {
-    return RouteUpdateModel(
+  RouteStatusUpdateModel copyWith({String? id, RouteStatus? status, RouteDetailModel? routeDetail}) {
+    return RouteStatusUpdateModel(
       id: id ?? this.id,
       status: status ?? this.status,
       routeDetail: routeDetail ?? this.routeDetail,

--- a/lib/features/campaigns/screens/route_detail.dart
+++ b/lib/features/campaigns/screens/route_detail.dart
@@ -183,7 +183,7 @@ class _RouteDetailState extends State<RouteDetail> {
 
   Future<void> _changeRouteStatus(RouteDetailModel route, bool state) async {
     var newStatus = state ? RouteStatus.closed : RouteStatus.open;
-    var routeUpdate = route.asRouteUpdate().copyWith(status: newStatus);
+    var routeUpdate = route.asRouteStatusUpdate().copyWith(status: newStatus);
 
     var feature = await _campaignActionCache.updatePoi(PoiCacheType.route, routeUpdate);
     await widget.mapController.setLayerSourceWithFeatureList(CampaignConstants.routesSourceName, [feature]);


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
using the new updateStatus interface for routes and areas

most work was already done, therefore most changes are just renaming some classes and using the correct interface in the service class

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #924

---