### PR TITLE
1009: Push notifications for mfa

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,7 +5,6 @@ analyzer:
     - build/**
     - lib/swagger_generated_code/**
     - lib/**.g.dart
-    - packages/**
   errors:
     always_use_package_imports: error
     directives_ordering: error

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,6 +47,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+         <meta-data
+          android:name="com.google.firebase.messaging.default_notification_icon"
+          android:resource="@drawable/ic_stat_notification_icon" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/lib/app/services/converters/remote_message_extension.dart
+++ b/lib/app/services/converters/remote_message_extension.dart
@@ -8,6 +8,8 @@ extension NullableRemoteMessageExtension on RemoteMessage? {
     switch (type) {
       case NotificationConstants.notificationTypeNews:
         return NotificationMessageType.news;
+      case NotificationConstants.notificationTypeMfa:
+        return NotificationMessageType.mfa;
       case NotificationConstants.notificationTypeTeamMembershipUpdated:
         return NotificationMessageType.teamMembershipUpdate;
       case NotificationConstants.notificationTypeTeamTop10Updated:
@@ -45,6 +47,8 @@ extension NotificationResponseExtension on NotificationResponse {
     if (localPayload == null) throw UnimplementedError();
     if (localPayload.startsWith(NotificationConstants.payloadNewsPrefix)) {
       instanceIdentifier = NotificationMessageType.news;
+    } else if (localPayload.startsWith(NotificationConstants.payloadMfa)) {
+      instanceIdentifier = NotificationMessageType.mfa;
     } else if (localPayload == NotificationConstants.payloadTeam) {
       instanceIdentifier = NotificationMessageType.teamMembershipUpdate;
     } else if (localPayload == NotificationConstants.payloadTeamTop10) {

--- a/lib/app/services/notification_message_type.dart
+++ b/lib/app/services/notification_message_type.dart
@@ -1,5 +1,6 @@
 enum NotificationMessageType {
   news,
+  mfa,
   teamMembershipUpdate,
   routeAssignmentUpdate,
   areaAssignmentUpdate,

--- a/lib/app/services/push_notification_handlers/mfa_notification_handler.dart
+++ b/lib/app/services/push_notification_handlers/mfa_notification_handler.dart
@@ -1,0 +1,24 @@
+part of 'notification_handlers.dart';
+
+class MfaNotificationHandler extends BaseNotificationHandler {
+  @override
+  void processMessage(RemoteMessage message, BuildContext? context) => _navigateToMfa(context);
+
+  @override
+  String? getPayload(RemoteMessage message) => NotificationConstants.payloadMfa;
+
+  @override
+  void processPayload(NotificationResponse response, BuildContext? context) => _navigateToMfa(context);
+
+  void _navigateToMfa(BuildContext? context) {
+    if (context == null) return;
+    final authBloc = context.read<AuthBloc>();
+    final isLoggedIn = authBloc.state is Authenticated;
+
+    if (isLoggedIn) {
+      GoRouter.of(context).go(RouteLocations.getRoute([RouteLocations.mfa]));
+    } else {
+      GoRouter.of(context).push(RouteLocations.getRoute([RouteLocations.mfaLogin]));
+    }
+  }
+}

--- a/lib/app/services/push_notification_handlers/notification_constants.dart
+++ b/lib/app/services/push_notification_handlers/notification_constants.dart
@@ -4,8 +4,10 @@ class NotificationConstants {
   static const String payloadTeamTop10 = 'teamTop10';
   static const String payloadTeam = 'team';
   static const String payloadNewsPrefix = 'news.';
+  static const String payloadMfa = 'mfa';
 
   static const notificationTypeNews = 'news.published';
+  static const notificationTypeMfa = 'mfa';
   static const notificationTypeTeamMembershipUpdated = 'campaigns.teamMembership.updated';
   static const notificationTypeTeamTop10Updated = 'campaigns.team-top10.updated';
   static const notificationTypeRouteAssignmentUpdated = 'campaigns.routeAssignment.updated';

--- a/lib/app/services/push_notification_handlers/notification_handlers.dart
+++ b/lib/app/services/push_notification_handlers/notification_handlers.dart
@@ -1,13 +1,16 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
+import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/constants/route_locations.dart';
 import 'package:gruene_app/features/campaigns/controllers/team_refresh_controller.dart';
 
 part 'base_notification_handler.dart';
 part 'news_notification_handler.dart';
+part 'mfa_notification_handler.dart';
 part 'team_notification_handler.dart';
 part 'team_top10_notification_handler.dart';
 part 'notification_constants.dart';

--- a/lib/features/mfa/bloc/mfa_bloc.dart
+++ b/lib/features/mfa/bloc/mfa_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_event.dart';
@@ -22,6 +23,14 @@ class MfaBloc extends Bloc<MfaEvent, MfaState> {
     if (state.status != MfaStatus.init) return;
     try {
       _authenticator = await _service.getFirst();
+
+      String? firebaseToken = await FirebaseMessaging.instance.getToken();
+      await _authenticator?.updateDevicePushId(devicePushId: firebaseToken);
+
+      FirebaseMessaging.instance.onTokenRefresh.listen(
+        (firebaseToken) async => await _authenticator?.updateDevicePushId(devicePushId: firebaseToken),
+      );
+
       emit(
         state.copyWith(
           status: _authenticator != null ? MfaStatus.ready : MfaStatus.setup,
@@ -38,7 +47,8 @@ class MfaBloc extends Bloc<MfaEvent, MfaState> {
     if (state.status != MfaStatus.setup || state.isLoading) return;
     emit(state.copyWith(isLoading: true, error: null));
     try {
-      _authenticator = await _service.create(event.activationToken);
+      String? firebaseToken = await FirebaseMessaging.instance.getToken();
+      _authenticator = await _service.create(event.activationToken, devicePushId: firebaseToken);
       emit(state.copyWith(status: MfaStatus.ready, isLoading: false, loginAttempt: null));
     } catch (error) {
       emit(state.copyWith(error: error, isLoading: false));

--- a/lib/features/mfa/screens/mfa_screen.dart
+++ b/lib/features/mfa/screens/mfa_screen.dart
@@ -4,7 +4,6 @@ import 'package:gruene_app/app/utils/error_message.dart';
 import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/app/widgets/app_bar.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_bloc.dart';
-import 'package:gruene_app/features/mfa/bloc/mfa_event.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_state.dart';
 import 'package:gruene_app/features/mfa/widgets/intro_view.dart';
 import 'package:gruene_app/features/mfa/widgets/ready_view.dart';
@@ -50,12 +49,6 @@ class _InitView extends StatefulWidget {
 }
 
 class _InitViewState extends State<_InitView> {
-  @override
-  void initState() {
-    super.initState();
-    context.read<MfaBloc>().add(InitMfa());
-  }
-
   @override
   Widget build(BuildContext context) {
     return const SizedBox.shrink();

--- a/lib/features/mfa/screens/mfa_screen.dart
+++ b/lib/features/mfa/screens/mfa_screen.dart
@@ -17,25 +17,27 @@ class MfaScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: MainAppBar(title: t.mfa.mfa),
-      body: BlocConsumer<MfaBloc, MfaState>(
-        listener: (context, state) {
-          final error = state.error;
-          if (error != null) {
-            showSnackBar(context, getErrorMessage(error));
-          }
-        },
-        builder: (context, state) {
-          switch (state.status) {
-            case MfaStatus.setup:
-              return const IntroView();
-            case MfaStatus.ready:
-              return const ReadyView();
-            case MfaStatus.verify:
-              return const VerifyView();
-            case MfaStatus.init:
-              return const _InitView();
-          }
-        },
+      body: SafeArea(
+        child: BlocConsumer<MfaBloc, MfaState>(
+          listener: (context, state) {
+            final error = state.error;
+            if (error != null) {
+              showSnackBar(context, getErrorMessage(error));
+            }
+          },
+          builder: (context, state) {
+            switch (state.status) {
+              case MfaStatus.setup:
+                return const IntroView();
+              case MfaStatus.ready:
+                return const ReadyView();
+              case MfaStatus.verify:
+                return const VerifyView();
+              case MfaStatus.init:
+                return const _InitView();
+            }
+          },
+        ),
       ),
     );
   }

--- a/lib/features/mfa/screens/token_input_screen.dart
+++ b/lib/features/mfa/screens/token_input_screen.dart
@@ -31,28 +31,30 @@ class _TokenInputScreenState extends State<TokenInputScreen> {
 
     return Scaffold(
       appBar: MainAppBar(title: t.mfa.tokenInput.title),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24),
-        child: ExpandingScrollView(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const SizedBox(height: 32),
-            Text(t.mfa.tokenInput.intro, style: theme.textTheme.titleMedium),
-            const SizedBox(height: 32),
-            Text(t.mfa.tokenInput.token, style: theme.textTheme.bodyMedium),
-            const SizedBox(height: 8),
-            TextField(controller: urlInput),
-            const SizedBox(height: 48),
-            FilledButton(
-              onPressed: () => {onSubmit(context)},
-              style: ButtonStyle(minimumSize: WidgetStateProperty.all<Size>(Size.fromHeight(56))),
-              child: Text(
-                t.mfa.tokenInput.submit,
-                style: theme.textTheme.titleMedium?.apply(color: theme.colorScheme.surface),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: ExpandingScrollView(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 32),
+              Text(t.mfa.tokenInput.intro, style: theme.textTheme.titleMedium),
+              const SizedBox(height: 32),
+              Text(t.mfa.tokenInput.token, style: theme.textTheme.bodyMedium),
+              const SizedBox(height: 8),
+              TextField(controller: urlInput),
+              const SizedBox(height: 48),
+              FilledButton(
+                onPressed: () => {onSubmit(context)},
+                style: ButtonStyle(minimumSize: WidgetStateProperty.all<Size>(Size.fromHeight(56))),
+                child: Text(
+                  t.mfa.tokenInput.submit,
+                  style: theme.textTheme.titleMedium?.apply(color: theme.colorScheme.surface),
+                ),
               ),
-            ),
-            const SizedBox(height: 32),
-          ],
+              const SizedBox(height: 32),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/mfa/screens/token_scan_screen.dart
+++ b/lib/features/mfa/screens/token_scan_screen.dart
@@ -21,50 +21,55 @@ class TokenScanScreen extends StatelessWidget {
     final theme = Theme.of(context);
     return Scaffold(
       appBar: MainAppBar(title: t.mfa.tokenScan.title),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24),
-        child: ExpandingScrollView(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const SizedBox(height: 72),
-            Text(t.mfa.tokenScan.intro, textAlign: TextAlign.center, style: theme.textTheme.titleMedium),
-            const SizedBox(height: 72),
-            Center(
-              child: Container(
-                width: 200,
-                height: 200,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(10),
-                  border: Border.all(color: theme.colorScheme.primary, width: 2),
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: MobileScanner(
-                    fit: BoxFit.cover,
-                    controller: MobileScannerController(
-                      detectionSpeed: DetectionSpeed.normal,
-                      detectionTimeoutMs: 4000,
-                      formats: const [BarcodeFormat.qrCode],
-                      autoStart: true,
-                      facing: CameraFacing.back,
-                      torchEnabled: false,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: ExpandingScrollView(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 72),
+              Text(t.mfa.tokenScan.intro, textAlign: TextAlign.center, style: theme.textTheme.titleMedium),
+              const SizedBox(height: 72),
+              Center(
+                child: Container(
+                  width: 200,
+                  height: 200,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(color: theme.colorScheme.primary, width: 2),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: MobileScanner(
+                      fit: BoxFit.cover,
+                      controller: MobileScannerController(
+                        detectionSpeed: DetectionSpeed.normal,
+                        detectionTimeoutMs: 4000,
+                        formats: const [BarcodeFormat.qrCode],
+                        autoStart: true,
+                        facing: CameraFacing.back,
+                        torchEnabled: false,
+                      ),
+                      onDetect: (barcode) => onDetect(barcode, context),
                     ),
-                    onDetect: (barcode) => onDetect(barcode, context),
                   ),
                 ),
               ),
-            ),
-            const SizedBox(height: 16),
-            Spacer(),
-            TextButton(
-              onPressed: () => context.pushNested(Routes.mfaTokenInput.path),
-              child: Text(
-                t.mfa.tokenScan.doManual,
-                style: theme.textTheme.bodyMedium!.apply(color: ThemeColors.text, decoration: TextDecoration.underline),
+              const SizedBox(height: 16),
+              Spacer(),
+              TextButton(
+                onPressed: () => context.pushNested(Routes.mfaTokenInput.path),
+                child: Text(
+                  t.mfa.tokenScan.doManual,
+                  style: theme.textTheme.bodyMedium!.apply(
+                    color: ThemeColors.text,
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
               ),
-            ),
-            const SizedBox(height: 32),
-          ],
+              const SizedBox(height: 32),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -123,6 +123,10 @@ Future<void> main() async {
     instanceName: NotificationMessageType.news.toString(),
   );
   GetIt.I.registerFactory<BaseNotificationHandler>(
+    () => MfaNotificationHandler(),
+    instanceName: NotificationMessageType.mfa.toString(),
+  );
+  GetIt.I.registerFactory<BaseNotificationHandler>(
     () => TeamNotificationHandler(),
     instanceName: NotificationMessageType.teamMembershipUpdate.toString(),
   );

--- a/packages/keycloak_authenticator/lib/src/authenticator.dart
+++ b/packages/keycloak_authenticator/lib/src/authenticator.dart
@@ -7,5 +7,6 @@ abstract class Authenticator {
   String? getLabel();
   Future<Challenge?> fetchChallenge();
   Future<void> reply({required Challenge challenge, required bool granted});
+  Future<void> updateDevicePushId({required String? devicePushId});
   // AuthenticatorInfo getInfo();
 }

--- a/packages/keycloak_authenticator/lib/src/authenticator_repository.dart
+++ b/packages/keycloak_authenticator/lib/src/authenticator_repository.dart
@@ -14,7 +14,7 @@ class AuthenticatorRepository {
     required Storage storage,
   }) : _storage = storage;
 
-  _getAuthenticatorStorageKey(String authenticatorId) {
+  String _getAuthenticatorStorageKey(String authenticatorId) {
     return "authr:$authenticatorId";
   }
 

--- a/packages/keycloak_authenticator/lib/src/authenticator_service.dart
+++ b/packages/keycloak_authenticator/lib/src/authenticator_service.dart
@@ -19,11 +19,11 @@ class AuthenticatorService {
   AuthenticatorService({required Storage storage}) : _repository = AuthenticatorRepository(storage: storage);
 
   Future<Authenticator> create(
-    String aktivationTokenUrl, {
+    String activationTokenUrl, {
     SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.SHA512withECDSA,
     String? label,
   }) async {
-    var token = ActivationTokenDto.fromUrl(aktivationTokenUrl);
+    var token = ActivationTokenDto.fromUrl(activationTokenUrl);
 
     // TODO: check if combination of keycloak instance an realm is already registered
 

--- a/packages/keycloak_authenticator/lib/src/authenticator_service.dart
+++ b/packages/keycloak_authenticator/lib/src/authenticator_service.dart
@@ -16,12 +16,14 @@ import 'package:uuid/uuid.dart';
 class AuthenticatorService {
   final AuthenticatorRepository _repository;
   final uuid = const Uuid();
+
   AuthenticatorService({required Storage storage}) : _repository = AuthenticatorRepository(storage: storage);
 
   Future<Authenticator> create(
     String activationTokenUrl, {
     SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.SHA512withECDSA,
     String? label,
+    required String? devicePushId,
   }) async {
     var token = ActivationTokenDto.fromUrl(activationTokenUrl);
 
@@ -42,7 +44,6 @@ class AuthenticatorService {
         break;
     }
 
-    var devicePushId = await DeviceUtils.getDevicePushId();
     DeviceOs deviceOs = DeviceUtils.getDeviceOs();
     var authenticatorId = uuid.v4();
 

--- a/packages/keycloak_authenticator/lib/src/keycloak_authenticator.dart
+++ b/packages/keycloak_authenticator/lib/src/keycloak_authenticator.dart
@@ -96,6 +96,14 @@ class KeycloakAuthenticator implements Authenticator {
       timestamp: challenge.updatedTimestamp,
     );
   }
+
+  @override
+  Future<void> updateDevicePushId({required String? devicePushId}) async {
+    await _client.updateDevicePushId(
+      deviceId: _data.id,
+      devicePushId: devicePushId,
+    );
+  }
 }
 
 class _Data {

--- a/packages/keycloak_authenticator/lib/src/keycloak_client.dart
+++ b/packages/keycloak_authenticator/lib/src/keycloak_client.dart
@@ -16,7 +16,7 @@ class KeycloakClient {
   final KeyAlgorithm _keyAlgorithm;
 
   KeycloakClient({
-    required baseUrl,
+    required String baseUrl,
     required SignatureAlgorithm signatureAlgorithm,
     required KeyAlgorithm keyAlgorithm,
     required PrivateKey privateKey,
@@ -160,7 +160,7 @@ class KeycloakClient {
     return (res.data as List<dynamic>).map((e) => Challenge.fromJson(e)).toList();
   }
 
-  replyChallenge({
+  Future<void> replyChallenge({
     required String deviceId,
     required String clientId,
     required String tabId,

--- a/packages/keycloak_authenticator/lib/src/keycloak_client.dart
+++ b/packages/keycloak_authenticator/lib/src/keycloak_client.dart
@@ -202,4 +202,35 @@ class KeycloakClient {
       ),
     );
   }
+
+  Future<void> updateDevicePushId({
+    required String deviceId,
+    required String? devicePushId,
+  }) async {
+    try {
+      await _updateDevicePushIdRequest(deviceId, devicePushId);
+    } on DioException catch (e) {
+      throw KeycloakClientException('Failed to update push notification token', dioException: e);
+    }
+  }
+
+  Future<void> _updateDevicePushIdRequest(String deviceId, String? devicePushId) async {
+    final signatureHeader = buildSignatureHeader(
+      deviceId,
+      {
+        'created': DateTime.now().millisecondsSinceEpoch.toString(),
+      },
+    );
+    await _dio.put(
+      '/$deviceId/credentials',
+      data: {
+        'devicePushId': devicePushId,
+      },
+      options: Options(
+        headers: {
+          'signature': signatureHeader,
+        },
+      ),
+    );
+  }
 }

--- a/packages/keycloak_authenticator/lib/src/utils/device_utils.dart
+++ b/packages/keycloak_authenticator/lib/src/utils/device_utils.dart
@@ -12,8 +12,4 @@ class DeviceUtils {
     }
     throw Exception("${Platform.operatingSystem} is not supported");
   }
-
-  static Future<String?> getDevicePushId() async {
-    return null;
-  }
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR implements push notifications for mfa login attempts.

Currently still blocked by https://github.com/netzbegruenung/keycloak-mfa-plugins/pull/353 and https://github.com/netzbegruenung/keycloak-mfa-plugins/pull/352.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Update keycloak devicePushId on mfa init, mfa setup and on token changes
- Open mfa on push notification press
- Fix push notification icon on android
- Add safe area views for mfa login screens
- Allow flutter analyze of packages
- Remove duplicated mfa init

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Setup mfa and login on another device and select the test device as second factor. Test notifications in foreground, background and quit stats and while logged in and not logged in. Press the push notification.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1009

---