### PR TITLE
1014: Allow approval of logins without authentication setup

### DIFF
--- a/lib/features/mfa/widgets/verify_view.dart
+++ b/lib/features/mfa/widgets/verify_view.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/app/widgets/expanding_scroll_view.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_bloc.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_event.dart';
@@ -18,7 +19,7 @@ class VerifyView extends StatefulWidget {
 }
 
 class _VerifyViewState extends State<VerifyView> {
-  final LocalAuthentication _auth = LocalAuthentication();
+  final LocalAuthentication _localAuthentication = LocalAuthentication();
 
   @override
   void initState() {
@@ -34,22 +35,33 @@ class _VerifyViewState extends State<VerifyView> {
   }
 
   Future<void> onReply(bool granted) async {
-    if (granted) {
-      try {
-        bool authenticated = await _auth.authenticate(
-          localizedReason: t.mfa.verify.authenticateForApproval,
-          persistAcrossBackgrounding: true,
-        );
-        if (!mounted) return;
-        context.read<MfaBloc>().add(SendReply(authenticated));
-      } catch (e) {
-        if (!mounted) return;
-        context.read<MfaBloc>().add(SendReply(false));
-      }
-    } else {
-      if (!mounted) return;
+    if (!granted) {
       context.read<MfaBloc>().add(SendReply(false));
+      return;
     }
+    try {
+      bool authenticated = await _authenticateUser();
+      if (authenticated && mounted) {
+        context.read<MfaBloc>().add(SendReply(true));
+        return;
+      }
+    } on LocalAuthException {
+      // Just show an error in the snackbar
+    }
+    if (mounted) {
+      showSnackBar(context, t.mfa.verify.authenticationFailed);
+    }
+  }
+
+  Future<bool> _authenticateUser() async {
+    if (!await _localAuthentication.isDeviceSupported()) {
+      return true;
+    }
+
+    return await _localAuthentication.authenticate(
+      localizedReason: t.mfa.verify.authenticateForApproval,
+      persistAcrossBackgrounding: true,
+    );
   }
 
   @override

--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -450,7 +450,8 @@
       "date": "Datum:",
       "time": "Uhrzeit:",
       "pointInTime": "${time} Uhr",
-      "authenticateForApproval": "Bitte bestätige die Anmeldung.",
+      "authenticateForApproval": "Bitte authentifiziere dich, um die Anmeldung zu bestätigen.",
+      "authenticationFailed": "Authentifizierung fehlgeschlagen. Bitte versuche es erneut.",
       "approve": "Anmeldung erlauben",
       "deny": "Anmeldung verweigern"
     }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Allow approval of logins with mfa even if no device authentication is set up.
Instead of rejecting login just show a client error if authentication was unsuccessful.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Allow approval of logins without device authentication
- Show an error if authentication fails
- Adjust the authentication message to `Bitte authentifiziere dich, um die Anmeldung zu bestätigen.`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
- Remove device authentication, try to login, use the app as 2nd factor and press approve. The login should then be successfully approved.
- Setup device authentication (e.g. pattern, face unlock, ...), try to login, use the app as 2nd factor, press approve and then go back without authenticating. Should show an error without rejecting the login. Then press approve again and authenticate. The login should then be successfully approved.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1014

---