### PR TITLE
992: Improve news images

### DIFF
--- a/lib/features/news/screens/news_detail_screen.dart
+++ b/lib/features/news/screens/news_detail_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:gruene_app/app/screens/error_screen.dart';
@@ -7,6 +6,7 @@ import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/app/utils/date.dart';
 import 'package:gruene_app/app/utils/divisions.dart';
 import 'package:gruene_app/app/widgets/app_bar.dart';
+import 'package:gruene_app/app/widgets/full_width_image.dart';
 import 'package:gruene_app/app/widgets/html.dart';
 import 'package:gruene_app/features/news/domain/news_api_service.dart';
 import 'package:gruene_app/features/news/models/news_model.dart';
@@ -38,7 +38,7 @@ class NewsDetailScreen extends StatelessWidget {
               children: [
                 SizedBox(
                   width: double.infinity,
-                  child: FullWidthImage(news: news),
+                  child: NewsDetailImage(news: news),
                 ),
                 Stack(
                   children: [
@@ -79,10 +79,10 @@ class NewsDetailScreen extends StatelessWidget {
   }
 }
 
-class FullWidthImage extends StatelessWidget {
+class NewsDetailImage extends StatelessWidget {
   final NewsModel news;
 
-  const FullWidthImage({super.key, required this.news});
+  const NewsDetailImage({super.key, required this.news});
 
   @override
   Widget build(BuildContext context) {
@@ -90,13 +90,7 @@ class FullWidthImage extends StatelessWidget {
     if (image == null) {
       return Image.asset('assets/graphics/placeholder.png', height: 256, fit: BoxFit.fitWidth);
     }
-
     final imageVariant = image.variant('wide');
-    final screenWidth = MediaQuery.sizeOf(context).width;
-    final imageHeight = imageVariant.height * screenWidth / imageVariant.width;
-    return CachedNetworkImage(
-      placeholder: (_, _) => SizedBox(height: imageHeight),
-      imageUrl: imageVariant.url,
-    );
+    return FullWidthImage(image: imageVariant.url, heightRatio: imageVariant.height / imageVariant.width);
   }
 }

--- a/lib/features/news/screens/news_detail_screen.dart
+++ b/lib/features/news/screens/news_detail_screen.dart
@@ -88,7 +88,7 @@ class FullWidthImage extends StatelessWidget {
   Widget build(BuildContext context) {
     final image = news.image;
     if (image == null) {
-      return Image.asset('assets/graphics/placeholder.png');
+      return Image.asset('assets/graphics/placeholder.png', height: 256, fit: BoxFit.fitWidth);
     }
 
     final imageVariant = image.variant('wide');


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Reopened #996 with correct base branch.
This PR makes news detail images tapable to display the whole image.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Reuse `FullWidthImage` to implement image opening on tap
- Set a max height for placeholder images

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Checkout some news and their images.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #992

---