### PR TITLE
1015: Add copy icon and only copy on tab if specified

### DIFF
--- a/lib/features/profiles/screens/own_profile_screen.dart
+++ b/lib/features/profiles/screens/own_profile_screen.dart
@@ -50,7 +50,7 @@ class OwnProfileScreen extends StatelessWidget {
                         title: t.profiles.baseData.phoneNumber,
                         value: profile.phoneNumbers.first.number,
                       ),
-                    ProfileCardListItem(title: t.profiles.personalId, value: profile.personalId),
+                    ProfileCardListItem(title: t.profiles.personalId, value: profile.personalId, copyOnTap: true),
                   ],
                 ),
                 if (profile.memberships?.isNotEmpty ?? false)

--- a/lib/features/profiles/widgets/profile_card_list_item.dart
+++ b/lib/features/profiles/widgets/profile_card_list_item.dart
@@ -6,14 +6,24 @@ class ProfileCardListItem extends StatelessWidget {
   final String value;
   final String? title;
   final String? url;
+  final bool copyOnTap;
 
-  const ProfileCardListItem({super.key, this.title, required this.value, this.url});
+  const ProfileCardListItem({super.key, this.title, required this.value, this.url, this.copyOnTap = false});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final title = this.title ?? value;
     final url = this.url;
+    final copyOnTap = this.copyOnTap ? () => Clipboard.setData(ClipboardData(text: value)) : null;
+    final copyIcon = this.copyOnTap
+        ? Column(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [Icon(Icons.copy, color: theme.disabledColor)],
+          )
+        : null;
+
     return ListTile(
       title: Text(title, style: this.title != null ? theme.textTheme.titleMedium : theme.textTheme.bodyLarge),
       subtitle: this.title != null
@@ -22,8 +32,9 @@ class ProfileCardListItem extends StatelessWidget {
               child: Text(value, style: theme.textTheme.bodyLarge?.apply(color: theme.colorScheme.primary)),
             )
           : null,
-      onTap: () => url != null ? openUrl(url, context) : Clipboard.setData(ClipboardData(text: value)),
-      trailing: url != null ? Icon(Icons.arrow_outward, color: theme.primaryColor) : null,
+      onTap: url != null ? () => openUrl(url, context) : copyOnTap,
+      onLongPress: () => Clipboard.setData(ClipboardData(text: url ?? value)),
+      trailing: url != null ? Icon(Icons.arrow_outward, color: theme.primaryColor) : copyIcon,
     );
   }
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Follow up to #1018. Adds a copy icon to the personal number and only copies the number on tab.
Everything else is only copied on long press.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add copy icon to the personal number
- Only copy content of other items on long press

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check out the profile and press/long press on the different items.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1015

---