### PR TITLE
1023: Fix crashes on events tab

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -97,10 +97,10 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
-  - MapLibre (6.25.1)
-  - maplibre_gl (0.26.0):
+  - MapLibre (6.14.0)
+  - maplibre_gl (0.0.1):
     - Flutter
-    - MapLibre (= 6.25.1)
+    - MapLibre (= 6.14.0)
   - mobile_scanner (7.0.0):
     - Flutter
     - FlutterMacOS
@@ -220,8 +220,8 @@ SPEC CHECKSUMS:
   image_cropper: fca51f94982730acae168c4b5d691e0f11aeb259
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
-  MapLibre: 117b8f7f7956137697fc72f7485261f65d770091
-  maplibre_gl: 42a8a898557cf24734708e47de0a0ce4b46e2aba
+  MapLibre: 69e572367f4ef6287e18246cfafc39c80cdcabcd
+  maplibre_gl: 3c924e44725147b03dda33430ad216005b40555f
   mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94

--- a/lib/app/widgets/location_button.dart
+++ b/lib/app/widgets/location_button.dart
@@ -56,7 +56,9 @@ class _LocationButtonState extends State<LocationButton> {
     final requestedPosition = _requestedPosition;
     return FloatingActionButton.small(
       heroTag: 'location',
-      onPressed: () => _followUserPosition(context),
+      onPressed: () => requestedPosition == null || requestedPosition.position == null
+          ? _determinePosition(context)
+          : widget.bringCameraToUser(requestedPosition),
       child: AnimatedSwitcher(
         duration: const Duration(milliseconds: 200),
         child: LocationIcon(requestedPosition: requestedPosition, followUserLocation: widget.followUserLocation),
@@ -78,15 +80,7 @@ class _LocationButtonState extends State<LocationButton> {
     );
   }
 
-  Future<void> _followUserPosition(BuildContext context) async {
-    final requestedPosition = _requestedPosition;
-    final position = requestedPosition == null || requestedPosition.position == null
-        ? await _determinePosition(context)
-        : requestedPosition;
-    widget.bringCameraToUser(position);
-  }
-
-  Future<RequestedPosition> _determinePosition(BuildContext context) async {
+  Future<void> _determinePosition(BuildContext context) async {
     setState(() => _requestedPosition = null);
     final requestedPosition = await determinePosition(
       context,
@@ -98,6 +92,6 @@ class _LocationButtonState extends State<LocationButton> {
       _showFeatureDisabled(context);
     }
 
-    return requestedPosition;
+    await widget.bringCameraToUser(requestedPosition);
   }
 }

--- a/lib/features/events/widgets/events_map.dart
+++ b/lib/features/events/widgets/events_map.dart
@@ -60,7 +60,7 @@ class _EventsMapState extends State<EventsMap> {
     }
   }
 
-  Future<void> _onFeatureTapped(math.Point<double> point, LatLng coordinates, _, String layer, _) async {
+  Future<void> _onFeatureTapped(_, math.Point<double> point, LatLng coordinates, String layer) async {
     final features = await mapController!.queryRenderedFeatures(point, ['events-layer'], null);
     final eventIds = features.map((feature) => feature['properties']['eventId'] as String?).nonNulls.toList();
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1037,6 +1037,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:
@@ -1168,26 +1176,26 @@ packages:
     dependency: "direct main"
     description:
       name: maplibre_gl
-      sha256: c97f32353b7c4d15e77c167cc444424556c0be7746dc73fd3deac5f32f858ed4
+      sha256: "5c7b1008396b2a321bada7d986ed60f9423406fbc7bd16f7ce91b385dfa054cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.0"
+    version: "0.22.0"
   maplibre_gl_platform_interface:
     dependency: "direct main"
     description:
       name: maplibre_gl_platform_interface
-      sha256: "60ee6ab5671de09dcf7fcb512aedb940024ed03dfcca04a4487dfdd76c906391"
+      sha256: "08ee0a2d0853ea945a0ab619d52c0c714f43144145cd67478fc6880b52f37509"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.0"
+    version: "0.22.0"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: "63988f302809a46667a40d8ae97882c13a2e0aa1f86808ba47a5e6f311471b59"
+      sha256: "2b13d4b1955a9a54e38a718f2324e56e4983c080fc6de316f6f4b5458baacb58"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.0"
+    version: "0.22.0"
   markdown:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,8 +35,8 @@ dependencies:
   jwt_decoder: ^2.0.1
   flutter_native_splash: ^2.4.2
   url_launcher: ^6.3.1
-  maplibre_gl: ^0.26.0
-  maplibre_gl_platform_interface: ^0.26.0
+  maplibre_gl: ^0.22.0
+  maplibre_gl_platform_interface: ^0.22.0
 #--------- swagger_dart_code_generator --------------
   chopper: ^8.0.0
   json_annotation: ^4.8.0


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Even with the workaround I implemented in 56773f5558c07391d7299d36f59d2a98342896ca, the app still crashes when opening the events tab on iOS. I am sadly a little clueless how to fix this, so I am just going to revert it.
This reverts commit 56773f5558c07391d7299d36f59d2a98342896ca.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Revert the maplibre upgrade and corresponding adjustments

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check out the map on iOS and verify that it does not crash.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---