### PR TITLE
Select scheme to fix ios fastlane builds

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -54,6 +54,7 @@ platform :ios do
 
     build_app(
        workspace: "Runner.xcworkspace",
+       scheme: "Runner",
        output_directory: "#{ENV['HOME']}",
        output_name: "app-release.ipa",
        export_method: "app-store",

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -21,15 +21,31 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 [bundle exec] fastlane ios build
 ```
 
-Create a release build
+Create an ios release build
 
-### ios upload_to_test_flight
+### ios beta_upload
 
 ```sh
-[bundle exec] fastlane ios upload_to_test_flight
+[bundle exec] fastlane ios beta_upload
 ```
 
-Deliver iOS App to TestFlight
+Deliver ios app to beta (testflight)
+
+### ios production_upload
+
+```sh
+[bundle exec] fastlane ios production_upload
+```
+
+Deliver ios app to production
+
+### ios promote
+
+```sh
+[bundle exec] fastlane ios promote
+```
+
+Promote the ios app from beta (testflight) to production
 
 ----
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
I added two more schemes in #1026. This now causes fastlane to fail for ios builds since it is not clear which scheme to use. Therefore select the default `Runner` scheme in fastlane.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Select `Runner` scheme in fastlane

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---