### PR TITLE
1043: Fix overflow on membership card

### DIFF
--- a/lib/features/profiles/screens/membership_card_screen.dart
+++ b/lib/features/profiles/screens/membership_card_screen.dart
@@ -24,10 +24,11 @@ class MembershipCardScreen extends StatelessWidget {
         buildChild: (Profile profile, _) {
           Division? partyDivision = profile.memberships?.partyDivision();
 
-          return Padding(
-            padding: defaultScreenPadding,
+          return ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: 640),
             child: Container(
-              padding: const EdgeInsets.fromLTRB(20, 24, 12, 12),
+              margin: defaultScreenPadding,
+              padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
                 gradient: const LinearGradient(
                   colors: [ThemeColors.primary, ThemeColors.secondary],
@@ -39,30 +40,29 @@ class MembershipCardScreen extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
+                spacing: 8,
                 children: [
                   Text(
                     t.profiles.membershipCard,
                     style: theme.textTheme.labelLarge?.copyWith(color: ThemeColors.background),
                   ),
-                  const SizedBox(height: 4),
                   Text(
                     '${profile.firstName}\n${profile.lastName}',
                     style: theme.textTheme.headlineLarge?.copyWith(color: ThemeColors.background),
                   ),
-                  if (partyDivision != null) ...[
-                    const SizedBox(height: 20),
+                  if (partyDivision != null)
                     Text(
                       partyDivision.displayName(),
                       style: theme.textTheme.titleSmall?.copyWith(color: ThemeColors.background),
                     ),
-                  ],
-                  const SizedBox(height: 80),
+                  Spacer(),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     crossAxisAlignment: CrossAxisAlignment.end,
                     children: [
                       Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
+                        spacing: 16,
                         children: [
                           RotatedBox(
                             quarterTurns: -1,
@@ -71,7 +71,6 @@ class MembershipCardScreen extends StatelessWidget {
                               style: theme.textTheme.labelLarge?.copyWith(color: ThemeColors.background),
                             ),
                           ),
-                          const SizedBox(height: 24),
                           CustomIcon(path: 'assets/icons/sunflower.svg', height: 48, color: ThemeColors.background),
                         ],
                       ),
@@ -80,7 +79,7 @@ class MembershipCardScreen extends StatelessWidget {
                         child: QrImageView(
                           data: profile.personalId,
                           version: QrVersions.auto,
-                          size: 212,
+                          size: 192,
                           backgroundColor: ThemeColors.background,
                         ),
                       ),

--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -403,7 +403,7 @@
     "homepage": "Homepage",
     "membershipCard": "Mitgliedskarte",
     "myMembershipCard": "Meine Mitgliedskarte",
-    "personalId": "Personen-/Kommunikationsnummer"
+    "personalId": "Personen-/Kommunikations-Nr."
   },
   "mfa": {
     "mfa": "2-Faktor-Authentifizierung",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -157,6 +157,11 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final authRepository = AuthRepository();
+    final shortestSide = MediaQuery.sizeOf(context).shortestSide;
+
+    if (shortestSide < 640) {
+      SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+    }
 
     return MultiBlocProvider(
       providers: [


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix the membership card overflow on small devices by better using the space.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use a dynamical spacer instead of a fixed height spacing
- Unify spacings
- Set a max height for the card
- Shorten the communication number label to `Personen-/Kommunikations-Nr.`
- Disable screen rotation on screen sizes <= 640 px

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See issue.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1043

---