### PR TITLE
989: enforce campaign selection when campaign gets inactive

### DIFF
--- a/lib/app/widgets/bottom_navigation.dart
+++ b/lib/app/widgets/bottom_navigation.dart
@@ -17,7 +17,7 @@ class BottomNavigation extends StatefulWidget {
 }
 
 class _BottomNavigationState extends State<BottomNavigation> {
-  final campaignValueStore = GetIt.I<CampaignValueStore>();
+  final campaignValueStore = GetIt.I<OpenInvitationCampaignValueStore>();
 
   @override
   void initState() {

--- a/lib/app/widgets/tab_bar.dart
+++ b/lib/app/widgets/tab_bar.dart
@@ -33,7 +33,7 @@ class CustomTabBar extends StatefulWidget implements PreferredSizeWidget {
 }
 
 class _CustomTabBarState extends State<CustomTabBar> {
-  final campaignValueStore = GetIt.I<CampaignValueStore>();
+  final campaignValueStore = GetIt.I<OpenInvitationCampaignValueStore>();
   void safeOnTap(int index) => widget.onTap(widget.tabs[index].disabled ? widget.tabController.previousIndex : index);
 
   @override

--- a/lib/features/campaigns/helper/app_timers.dart
+++ b/lib/features/campaigns/helper/app_timers.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/auth/repository/auth_repository.dart';
+import 'package:gruene_app/app/services/gruene_api_campaign_service.dart';
 import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
+import 'package:gruene_app/app/utils/campaign.dart';
 import 'package:gruene_app/features/campaigns/helper/background_timer.dart';
 import 'package:gruene_app/features/campaigns/helper/campaign_action_cache.dart';
+import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 import 'package:http/http.dart';
 
 class AppTimers {
@@ -13,6 +16,10 @@ class AppTimers {
 
   static BackgroundTimer getOpenInvitationTimer() {
     return BackgroundTimer(onTimer: _reloadOpenInvitations, runEvery: Duration(minutes: 1));
+  }
+
+  static BackgroundTimer getEnforceActiveCampaignTimer() {
+    return BackgroundTimer(onTimer: _checkCurrentCampaignIsActive, runEvery: Duration(minutes: 1));
   }
 
   static void _flushCacheData() async {
@@ -25,12 +32,19 @@ class AppTimers {
   static Future<void> _reloadOpenInvitations() async {
     var authRepo = AuthRepository();
     if (await authRepo.getAccessToken() != null) {
-      GetIt.I<CampaignValueStore>().reloadOpenInvitations();
+      GetIt.I<OpenInvitationCampaignValueStore>().reloadOpenInvitations();
+    }
+  }
+
+  static void _checkCurrentCampaignIsActive() async {
+    var authRepo = AuthRepository();
+    if (await authRepo.getAccessToken() != null) {
+      GetIt.I<ActiveCampaignNotifier>().checkCurrentCampaignIsActive();
     }
   }
 }
 
-class CampaignValueStore extends ChangeNotifier {
+class OpenInvitationCampaignValueStore extends ChangeNotifier {
   int _openInvitationCount = 0;
   int get openInvitations => _openInvitationCount;
 
@@ -44,5 +58,31 @@ class CampaignValueStore extends ChangeNotifier {
     } on ClientException {
       // Don't crash the app on network errors
     }
+  }
+}
+
+class ActiveCampaignNotifier extends ChangeNotifier {
+  bool _isCurrentCampaignActive = true;
+  bool get isCurrentCampaignActive => _isCurrentCampaignActive;
+
+  void checkCurrentCampaignIsActive() async {
+    try {
+      var currentCampaignId = getCurrentCampaignId();
+      var isActive = false;
+      if (currentCampaignId != null) {
+        var allCampaigns = await GetIt.I<GrueneApiCampaignService>().findCampaigns();
+        isActive = allCampaigns.any((c) => c.id == currentCampaignId && c.status == CampaignStatus.active);
+      }
+      _isCurrentCampaignActive = isActive;
+      if (!isActive) {
+        notifyListeners();
+      }
+    } on ClientException {
+      // Don't crash the app on network errors
+    }
+  }
+
+  void reset() {
+    _isCurrentCampaignActive = true;
   }
 }

--- a/lib/features/campaigns/screens/campaign_select_button.dart
+++ b/lib/features/campaigns/screens/campaign_select_button.dart
@@ -1,7 +1,4 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
-import 'package:gruene_app/app/constants/design_constants.dart';
 import 'package:gruene_app/features/campaigns/screens/campaign_select_widget.dart';
 
 class CampaignSelectButton extends StatelessWidget {
@@ -9,21 +6,13 @@ class CampaignSelectButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return IconButton(icon: const Icon(Icons.how_to_vote_outlined), onPressed: () => showCampaignSelectDialog(context));
+    return IconButton(
+      icon: const Icon(Icons.how_to_vote_outlined),
+      onPressed: () => _showCampaignSelectDialog(context),
+    );
   }
 
-  void showCampaignSelectDialog(BuildContext context) async {
-    final theme = Theme.of(context);
-    await showModalBottomSheet<void>(
-      context: context,
-      builder: (context) => Padding(
-        padding: EdgeInsets.only(bottom: max(MediaQuery.of(context).viewInsets.bottom, DesignConstants.bottomPadding)),
-        child: CampaignSelectWidget(),
-      ),
-      isScrollControlled: true,
-      isDismissible: true,
-      useRootNavigator: true,
-      backgroundColor: theme.colorScheme.surface,
-    );
+  void _showCampaignSelectDialog(BuildContext context) async {
+    await showCampaignSelectDialog(context);
   }
 }

--- a/lib/features/campaigns/screens/campaign_select_widget.dart
+++ b/lib/features/campaigns/screens/campaign_select_widget.dart
@@ -1,5 +1,8 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:gruene_app/app/constants/design_constants.dart';
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_campaign_service.dart';
 import 'package:gruene_app/app/services/gruene_api_divisions_service.dart';
@@ -8,11 +11,15 @@ import 'package:gruene_app/app/utils/app_settings.dart';
 import 'package:gruene_app/app/utils/campaign.dart';
 import 'package:gruene_app/app/utils/utils.dart';
 import 'package:gruene_app/app/widgets/dialog_close_button.dart';
+import 'package:gruene_app/features/campaigns/helper/app_timers.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
 class CampaignSelectWidget extends StatefulWidget {
-  const CampaignSelectWidget({super.key});
+  final bool enforceSelect;
+  static int showCounter = 0;
+
+  const CampaignSelectWidget({super.key, this.enforceSelect = false});
 
   @override
   State<CampaignSelectWidget> createState() => _CampaignSelectWidgetState();
@@ -23,35 +30,47 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
   bool _loading = true;
   List<Campaign> _activeCampaigns = [];
   List<Division> _activeCampaignDivisions = [];
+  String _previousCampaignName = t.common.unknown;
 
   @override
   void initState() {
     super.initState();
+    CampaignSelectWidget.showCounter++;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadData();
     });
   }
 
+  @override
+  dispose() {
+    super.dispose();
+    CampaignSelectWidget.showCounter--;
+  }
+
   void _loadData() async {
     setState(() => _loading = true);
 
+    var selectedCampaignId = getCurrentCampaignId();
+
     var campaignService = GetIt.I<GrueneApiCampaignService>();
     var allCampaigns = await campaignService.findCampaigns();
-
-    var activeCampaigns = allCampaigns.where((c) => c.status == CampaignStatus.active).toList();
+    var activeCampaigns = allCampaigns.activeCampaigns();
     activeCampaigns.sort((a, b) => a.electionDate.compareTo(b.electionDate));
 
     var divisionKeys = activeCampaigns.groupBy((c) => c.divisionKey).keys.toList();
     var divisionService = GetIt.I<GrueneApiDivisionsService>();
     var activeCampaignDivisions = await divisionService.searchDivision(divisionKeys: divisionKeys);
 
-    var selectedCampaignId = getCurrentCampaignId();
+    var previousCampaignName = widget.enforceSelect && selectedCampaignId != null
+        ? allCampaigns.firstWhereOrNull((c) => c.id == selectedCampaignId)?.name ?? t.common.unknown
+        : t.common.unknown;
 
     setState(() {
       _loading = false;
       _activeCampaigns = activeCampaigns;
       _activeCampaignDivisions = activeCampaignDivisions;
       _selectedCampaignId = selectedCampaignId;
+      _previousCampaignName = previousCampaignName;
     });
   }
 
@@ -71,7 +90,12 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
                 DialogCloseButton(onClose: _closeAndSave),
               ],
             ),
-            Text(t.campaigns.select.hint, style: theme.textTheme.bodySmall),
+            Text(
+              widget.enforceSelect
+                  ? t.campaigns.select.enforceSelectHint(previousCampaignName: _previousCampaignName)
+                  : t.campaigns.select.hint,
+              style: theme.textTheme.bodySmall,
+            ),
             SizedBox(height: 16),
             _loading
                 ? Padding(padding: EdgeInsets.all(24), child: CircularProgressIndicator())
@@ -93,9 +117,15 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
   }
 
   void _closeAndSave() {
+    if (widget.enforceSelect && !_activeCampaigns.isCampaignActive(_selectedCampaignId)) {
+      // Don't allow closing without selection if selection is enforced
+      return;
+    }
     var appSettings = GetIt.I<AppSettings>();
     appSettings.campaign.activeCampaign.recentSelectedCampaignId = _selectedCampaignId;
-    Navigator.of(context).pop();
+    GetIt.I<ActiveCampaignNotifier>().reset();
+
+    Navigator.of(context).pop(true);
   }
 
   Widget _getCampaignRadioTile(Campaign c, ThemeData theme) {
@@ -120,5 +150,45 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
         materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       ),
     );
+  }
+}
+
+Future<void> showCampaignSelectDialog(BuildContext context, {bool enforceSelect = false}) async {
+  if (CampaignSelectWidget.showCounter > 0) {
+    // Prevent multiple dialogs from being opened at the same time
+    return;
+  }
+
+  var isDismissible = !enforceSelect;
+
+  final theme = Theme.of(context);
+  while (true) {
+    var dialogResult = await showModalBottomSheet<bool>(
+      context: context,
+      builder: (context) => Padding(
+        padding: EdgeInsets.only(bottom: max(MediaQuery.of(context).viewInsets.bottom, DesignConstants.bottomPadding)),
+        child: CampaignSelectWidget(enforceSelect: enforceSelect),
+      ),
+      isScrollControlled: true,
+      isDismissible: isDismissible,
+      useRootNavigator: true,
+      backgroundColor: theme.colorScheme.surface,
+    );
+    if (enforceSelect && (dialogResult == null || dialogResult == false)) {
+      // If selection is enforced, we need to show the dialog again if the user dismissed it without selecting
+      continue;
+    }
+    break;
+  }
+}
+
+extension CampaignListExtension on List<Campaign> {
+  List<Campaign> activeCampaigns() {
+    return where((c) => c.status == CampaignStatus.active).toList();
+  }
+
+  bool isCampaignActive(String? campaignId) {
+    if (campaignId == null) return false;
+    return activeCampaigns().any((c) => c.id == campaignId);
   }
 }

--- a/lib/features/campaigns/screens/campaigns_screen.dart
+++ b/lib/features/campaigns/screens/campaigns_screen.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:gruene_app/app/enums/badge_source.dart';
 import 'package:gruene_app/app/screens/router_tab_screen.dart';
 import 'package:gruene_app/app/widgets/app_bar.dart';
 import 'package:gruene_app/app/widgets/tab_bar.dart';
+import 'package:gruene_app/features/campaigns/helper/app_timers.dart';
 import 'package:gruene_app/features/campaigns/screens/campaign_select_button.dart';
+import 'package:gruene_app/features/campaigns/screens/campaign_select_widget.dart';
 import 'package:gruene_app/features/campaigns/widgets/refresh_button.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 
@@ -25,6 +29,16 @@ class CampaignsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    var activeCampaignNotifier = GetIt.I<ActiveCampaignNotifier>();
+    if (!activeCampaignNotifier.isCurrentCampaignActive) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        showCampaignSelectDialog(context, enforceSelect: true);
+      });
+    }
+    activeCampaignNotifier.addListener(() {
+      showCampaignSelectDialog(context, enforceSelect: true);
+    });
+
     return RouterTabScreen(
       appBarBuilder: (PreferredSizeWidget tabBar) => MainAppBar(
         title: t.campaigns.campaigns,

--- a/lib/features/campaigns/screens/teams/open_invitation_list.dart
+++ b/lib/features/campaigns/screens/teams/open_invitation_list.dart
@@ -49,7 +49,7 @@ class _OpenInvitationListState extends State<OpenInvitationList> {
 
       // enforce reload of open invitations in campaign value store
       // if the number of open invitations has changed since the last load
-      var store = GetIt.I<CampaignValueStore>();
+      var store = GetIt.I<OpenInvitationCampaignValueStore>();
       if (_openInvitations.length != store.openInvitations) {
         store.reloadOpenInvitations();
       }
@@ -179,14 +179,14 @@ class _OpenInvitationListState extends State<OpenInvitationList> {
     }
     var teamService = GetIt.I<GrueneApiTeamsService>();
     await teamService.acceptTeamMembership(invitation.teamId);
-    GetIt.I<CampaignValueStore>().reloadOpenInvitations();
+    GetIt.I<OpenInvitationCampaignValueStore>().reloadOpenInvitations();
     widget.reload();
   }
 
   Future<void> _rejectInvitation(TeamInvitation invitation) async {
     var teamService = GetIt.I<GrueneApiTeamsService>();
     await teamService.rejectTeamMembership(invitation.teamId);
-    GetIt.I<CampaignValueStore>().reloadOpenInvitations();
+    GetIt.I<OpenInvitationCampaignValueStore>().reloadOpenInvitations();
     widget.reload();
   }
 }

--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -124,6 +124,7 @@
     "select":{
       "title": "Kampagne auswählen",
       "hint": "In welcher Kampagne bist du gerade aktiv? Du kannst die Kampagne jederzeit in deinen Einstellungen ändern.",
+      "enforceSelectHint": "Deine bisherige Kampagne '${previousCampaignName}' ist beendet. Bitte wähle eine neue Kampagne aus!",
       "electionDate": "Wahltermin"
     },
     "infoToast": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -94,12 +94,17 @@ Future<void> main() async {
   GetIt.I.registerSingleton<ProfileFeatureChecker>(ProfileFeatureChecker());
   GetIt.I.registerFactory<NominatimService>(() => NominatimService(countryCode: t.campaigns.search.country_code));
   GetIt.I.registerSingleton<CampaignActionCache>(CampaignActionCache());
-  GetIt.I.registerSingleton<CampaignValueStore>(CampaignValueStore());
+  GetIt.I.registerSingleton<OpenInvitationCampaignValueStore>(OpenInvitationCampaignValueStore());
+  GetIt.I.registerSingleton<ActiveCampaignNotifier>(ActiveCampaignNotifier());
   GetIt.I.registerSingleton<BackgroundTimer>(
     AppTimers.getCampaignActionCacheTimer(),
     instanceName: 'campaignActionCacheTimer',
   );
   GetIt.I.registerSingleton<BackgroundTimer>(AppTimers.getOpenInvitationTimer(), instanceName: 'openInvitationTimer');
+  GetIt.I.registerSingleton<BackgroundTimer>(
+    AppTimers.getEnforceActiveCampaignTimer(),
+    instanceName: 'enforceActiveCampaignTimer',
+  );
   GetIt.I.registerSingleton<FileManager>(FileManager());
   GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.poster.toString());
   GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.flyer.toString());


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Currently selected campaign is regularly checked (every minute)
- if the current campaign gets inactive (or is not set) a dialog is shown to enforce a selection

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #989

---