### PR TITLE
Fix party name

### DIFF
--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "appName": "B90/DIE GRÜNEN",
-    "party": "Bündnis 90/DIE GRÜNEN",
+    "party": "BÜNDNIS 90/DIE GRÜNEN",
     "error": "Fehler",
     "dateFrom": "von",
     "dateUntil": "bis",
@@ -84,7 +84,7 @@
   "profile": {
     "visibility_setting": {
       "visibility_setting_action": "Sichtbarkeitseinstellungen",
-      "title": "Mein Profil ist einsehbar für Mitglieder*innen ...",
+      "title": "Mein Profil ist einsehbar für Mitglieder ...",
       "visibility_public": "... für alle (ganze Partei)",
       "visibility_BV": "... im Bundesverband",
       "visibility_LV": "... im Landesverband",


### PR DESCRIPTION
### Short Description

Fixes the Partyname to align with Corporate Design: https://design.gruene.de/4ccd94a80/p/0558bf-sprache

Fixes the Spelling of Member.

### Proposed Changes
- change Partyname from Bündnis 90/DIE GRÜNEN to BÜNDNIS 90/DIE GRÜNEN
- change Mitglieder*innen to Mitglieder

### Side Effects

N/A

### Testing

- Go to Mitglieder > Meine Mitgliedskarte

### Resolved Issues

N/A

Fixes: 