### PR TITLE
1029: Add loading overlay for logout

### DIFF
--- a/lib/app/auth/bloc/auth_bloc.dart
+++ b/lib/app/auth/bloc/auth_bloc.dart
@@ -1,14 +1,20 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/auth/repository/auth_repository.dart';
 import 'package:gruene_app/app/services/push_notification_service.dart';
 import 'package:gruene_app/app/utils/app_settings.dart';
+import 'package:gruene_app/app/utils/loading_overlay.dart';
 
 class AuthEvent {}
 
 class LoginRequested extends AuthEvent {}
 
-class LogoutRequested extends AuthEvent {}
+class LogoutRequested extends AuthEvent {
+  final BuildContext context;
+
+  LogoutRequested(this.context);
+}
 
 class CheckTokenRequested extends AuthEvent {}
 
@@ -40,10 +46,15 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     });
 
     on<LogoutRequested>((event, emit) async {
-      await authRepository.logout();
-      await _pushNotificationService.updateSubscriptions();
-      AppSettings.register();
-      emit(Unauthenticated());
+      await tryAndNotify(
+        function: () async {
+          await authRepository.logout();
+          await _pushNotificationService.updateSubscriptions();
+          AppSettings.register();
+          emit(Unauthenticated());
+        },
+        context: event.context,
+      );
     });
 
     on<CheckTokenRequested>((event, emit) async {

--- a/lib/app/utils/loading_overlay.dart
+++ b/lib/app/utils/loading_overlay.dart
@@ -26,7 +26,7 @@ void hideLoadingOverlay() {
 Future<T?> tryAndNotify<T>({
   required Future<T> Function() function,
   required BuildContext context,
-  required String successMessage,
+  String? successMessage,
   String? errorMessage,
   void Function(bool loading)? setLoading,
 }) async {
@@ -34,7 +34,7 @@ Future<T?> tryAndNotify<T>({
   setLoading != null ? setLoading(true) : showLoadingOverlay(context);
   try {
     final value = await function();
-    if (rootContext.mounted) {
+    if (successMessage != null && rootContext.mounted) {
       showSnackBar(rootContext, successMessage);
     }
     return value;

--- a/lib/app/utils/profile_feature_checker.dart
+++ b/lib/app/utils/profile_feature_checker.dart
@@ -62,10 +62,11 @@ class ProfileFeatureChecker {
   }
 
   Future<String?> _getCurrentUserId(String? currentAccessToken) async {
-    var jwtToken = JwtDecoder.decode(currentAccessToken!);
-    String? userId;
-    if (jwtToken.containsKey('uidnumber')) userId = jwtToken['uidnumber'].toString();
-    return userId;
+    final jwtToken = currentAccessToken != null ? JwtDecoder.decode(currentAccessToken) : null;
+    if (jwtToken != null && jwtToken.containsKey('uidnumber')) {
+      return jwtToken['uidnumber'].toString();
+    }
+    return null;
   }
 
   void _showProfileSettingDialog(BuildContext context, Profile currentProfile) async {

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -51,7 +51,7 @@ class SettingsScreen extends StatelessWidget {
               ? Padding(
                   padding: const EdgeInsets.only(top: 24),
                   child: OutlinedButton.icon(
-                    onPressed: () => context.read<AuthBloc>().add(LogoutRequested()),
+                    onPressed: () => context.read<AuthBloc>().add(LogoutRequested(context)),
                     label: Text(t.settings.logout),
                     icon: Icon(Icons.logout),
                   ),


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Add a loading overlay preventing user interactions on logout.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Show a blocking loading overlay on user logout until the logout is completed
- Keep the login as it is, no overlay is necessary as the login is done in the inapp browser
- Allow using tryAndNotify without a success message
- Fix exception if there is no user

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to settings and tap logout. See the loading overlay and try to interact with the app.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1029

---