### PR TITLE
#1010 campaign statistics

### DIFF
--- a/lib/app/services/converters.dart
+++ b/lib/app/services/converters.dart
@@ -96,3 +96,4 @@ part 'converters/user_info_extensions.dart';
 part 'converters/team_assignment_type_extension.dart';
 part 'converters/divison_level_extensions.dart';
 part 'converters/widget_extension.dart';
+part 'converters/campaign_list_extension.dart';

--- a/lib/app/services/converters/campaign_list_extension.dart
+++ b/lib/app/services/converters/campaign_list_extension.dart
@@ -1,0 +1,16 @@
+part of '../converters.dart';
+
+extension CampaignListExtension on List<Campaign> {
+  List<Campaign> activeCampaigns() {
+    return where((c) => c.status == CampaignStatus.active).toList();
+  }
+
+  List<Campaign> activeAndClosedCampaigns() {
+    return where((c) => [CampaignStatus.active, CampaignStatus.closed].contains(c.status)).toList();
+  }
+
+  bool isCampaignActive(String? campaignId) {
+    if (campaignId == null) return false;
+    return activeCampaigns().any((c) => c.id == campaignId);
+  }
+}

--- a/lib/app/services/gruene_api_campaigns_statistics_service.dart
+++ b/lib/app/services/gruene_api_campaigns_statistics_service.dart
@@ -1,19 +1,15 @@
-import 'package:get_it/get_it.dart';
+import 'package:gruene_app/app/services/gruene_api_base_service.dart';
 import 'package:gruene_app/features/campaigns/models/statistics/campaign_statistics_model.dart';
 import 'package:gruene_app/features/campaigns/models/statistics/campaign_statistics_set.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
-class GrueneApiCampaignsStatisticsService {
-  late GrueneApi grueneApi;
+class GrueneApiCampaignsStatisticsService extends GrueneApiBaseService {
+  GrueneApiCampaignsStatisticsService() : super();
 
-  GrueneApiCampaignsStatisticsService() {
-    grueneApi = GetIt.I<GrueneApi>();
-  }
-
-  Future<CampaignStatisticsModel> getStatistics() async {
-    var statResult = await grueneApi.v1CampaignsStatisticsGet();
-    return statResult.body!.asCampaignStatistics();
-  }
+  Future<CampaignStatisticsModel> getStatistics({required String? campaigndId}) async => getFromApi(
+    apiRequest: (api) => api.v1CampaignsStatisticsGet(campaignId: campaigndId),
+    map: (result) => result.asCampaignStatistics(),
+  );
 }
 
 extension StatisticsParser on CampaignStatistics {

--- a/lib/app/services/gruene_api_teams_service.dart
+++ b/lib/app/services/gruene_api_teams_service.dart
@@ -77,8 +77,9 @@ class GrueneApiTeamsService extends GrueneApiBaseService {
     map: (data) => data.data,
   );
 
-  Future<TeamMembershipStatistics> getTeamMembershipStatistics() =>
-      getFromApi(apiRequest: (api) => api.v1CampaignsTeamsSelfMembershipStatisticsGet());
+  Future<TeamMembershipStatistics> getTeamMembershipStatistics({required String? campaignId}) =>
+      getFromApi(apiRequest: (api) => api.v1CampaignsTeamsSelfMembershipStatisticsGet(campaignId: campaignId));
 
-  Future<TeamStatistics> getTeamStatistics() => getFromApi(apiRequest: (api) => api.v1CampaignsTeamsStatisticsGet());
+  Future<TeamStatistics> getTeamStatistics({required String? campaignId}) =>
+      getFromApi(apiRequest: (api) => api.v1CampaignsTeamsStatisticsGet(campaignId: campaignId));
 }

--- a/lib/app/utils/campaign.dart
+++ b/lib/app/utils/campaign.dart
@@ -5,3 +5,11 @@ String? getCurrentCampaignId() {
   var appSettings = GetIt.I<AppSettings>();
   return appSettings.campaign.activeCampaign.recentSelectedCampaignId;
 }
+
+String? getCurrentPoiStatisticsCampaignId() {
+  var appSettings = GetIt.I<AppSettings>();
+  var currentCampaignId =
+      appSettings.campaign.recentPoiStatisticsCampaignId ??
+      appSettings.campaign.activeCampaign.recentSelectedCampaignId;
+  return currentCampaignId;
+}

--- a/lib/features/campaigns/helper/active_campaign_settings.dart
+++ b/lib/features/campaigns/helper/active_campaign_settings.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/constants/secure_storage_keys.dart';
+import 'package:gruene_app/app/utils/app_settings.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'active_campaign_settings.g.dart';
@@ -17,6 +18,7 @@ class ActiveCampaignSettings extends ChangeNotifier {
 
   set recentSelectedCampaignId(String? recentSelectedCampaignId) {
     _recentSelectedCampaignId = recentSelectedCampaignId;
+    GetIt.I<AppSettings>().campaign.recentPoiStatisticsCampaignId = null;
     save();
     notifyListeners();
   }

--- a/lib/features/campaigns/helper/campaign_session_settings.dart
+++ b/lib/features/campaigns/helper/campaign_session_settings.dart
@@ -14,6 +14,8 @@ class CampaignSessionSettings {
   String? searchString;
   List<SearchResultItem>? searchResult = [];
 
+  String? recentPoiStatisticsCampaignId;
+
   CampaignStatisticsModel? recentPoiStatistics;
   DateTime? recentPoiStatisticsFetchTimestamp;
 

--- a/lib/features/campaigns/helper/enums.dart
+++ b/lib/features/campaigns/helper/enums.dart
@@ -3,3 +3,5 @@ enum ModalEditResult { cancel, save, delete }
 enum ModalDetailResult { close, edit }
 
 enum ImageType { jpeg, png }
+
+enum CampaignSelectMode { normal, enforceSelect, statistics }

--- a/lib/features/campaigns/screens/campaign_select_widget.dart
+++ b/lib/features/campaigns/screens/campaign_select_widget.dart
@@ -12,14 +12,15 @@ import 'package:gruene_app/app/utils/campaign.dart';
 import 'package:gruene_app/app/utils/utils.dart';
 import 'package:gruene_app/app/widgets/dialog_close_button.dart';
 import 'package:gruene_app/features/campaigns/helper/app_timers.dart';
+import 'package:gruene_app/features/campaigns/helper/enums.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
 class CampaignSelectWidget extends StatefulWidget {
-  final bool enforceSelect;
+  final CampaignSelectMode mode;
   static int showCounter = 0;
 
-  const CampaignSelectWidget({super.key, this.enforceSelect = false});
+  const CampaignSelectWidget({super.key, this.mode = CampaignSelectMode.normal});
 
   @override
   State<CampaignSelectWidget> createState() => _CampaignSelectWidgetState();
@@ -50,24 +51,30 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
   void _loadData() async {
     setState(() => _loading = true);
 
-    var selectedCampaignId = getCurrentCampaignId();
+    var selectedCampaignId = switch (widget.mode) {
+      CampaignSelectMode.normal || CampaignSelectMode.enforceSelect => getCurrentCampaignId(),
+      CampaignSelectMode.statistics => getCurrentPoiStatisticsCampaignId(),
+    };
 
     var campaignService = GetIt.I<GrueneApiCampaignService>();
     var allCampaigns = await campaignService.findCampaigns();
-    var activeCampaigns = allCampaigns.activeCampaigns();
-    activeCampaigns.sort((a, b) => a.electionDate.compareTo(b.electionDate));
+    var selectableCampaigns = switch (widget.mode) {
+      CampaignSelectMode.normal || CampaignSelectMode.enforceSelect => allCampaigns.activeCampaigns(),
+      CampaignSelectMode.statistics => allCampaigns.activeAndClosedCampaigns(),
+    };
+    selectableCampaigns.sort((a, b) => a.electionDate.compareTo(b.electionDate));
 
-    var divisionKeys = activeCampaigns.groupBy((c) => c.divisionKey).keys.toList();
+    var divisionKeys = selectableCampaigns.groupBy((c) => c.divisionKey).keys.toList();
     var divisionService = GetIt.I<GrueneApiDivisionsService>();
     var activeCampaignDivisions = await divisionService.searchDivision(divisionKeys: divisionKeys);
 
-    var previousCampaignName = widget.enforceSelect && selectedCampaignId != null
+    var previousCampaignName = widget.mode == CampaignSelectMode.enforceSelect && selectedCampaignId != null
         ? allCampaigns.firstWhereOrNull((c) => c.id == selectedCampaignId)?.name ?? t.common.unknown
         : t.common.unknown;
 
     setState(() {
       _loading = false;
-      _activeCampaigns = activeCampaigns;
+      _activeCampaigns = selectableCampaigns;
       _activeCampaignDivisions = activeCampaignDivisions;
       _selectedCampaignId = selectedCampaignId;
       _previousCampaignName = previousCampaignName;
@@ -76,9 +83,27 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
 
   @override
   Widget build(BuildContext context) {
+    var titleText = '', hintText = '', height = 300.0;
+
+    switch (widget.mode) {
+      case CampaignSelectMode.normal:
+        titleText = t.campaigns.select.title;
+        hintText = t.campaigns.select.hint;
+        break;
+      case CampaignSelectMode.enforceSelect:
+        titleText = t.campaigns.select.title;
+        hintText = t.campaigns.select.enforceSelectHint(previousCampaignName: _previousCampaignName);
+        break;
+      case CampaignSelectMode.statistics:
+        titleText = t.campaigns.select.statisticsTitle;
+        hintText = t.campaigns.select.statisticsHint;
+        height = 450;
+        break;
+    }
+
     var theme = Theme.of(context);
     return SizedBox(
-      height: 300,
+      height: height,
       child: Container(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -86,16 +111,11 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(t.campaigns.select.title, style: theme.textTheme.titleLarge),
+                Text(titleText, style: theme.textTheme.titleLarge),
                 DialogCloseButton(onClose: _closeAndSave),
               ],
             ),
-            Text(
-              widget.enforceSelect
-                  ? t.campaigns.select.enforceSelectHint(previousCampaignName: _previousCampaignName)
-                  : t.campaigns.select.hint,
-              style: theme.textTheme.bodySmall,
-            ),
+            Text(hintText, style: theme.textTheme.bodySmall),
             SizedBox(height: 16),
             _loading
                 ? Padding(padding: EdgeInsets.all(24), child: CircularProgressIndicator())
@@ -106,7 +126,14 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
                         onChanged: (value) => setState(() {
                           _selectedCampaignId = value!;
                         }),
-                        child: Column(children: _activeCampaigns.map((c) => _getCampaignRadioTile(c, theme)).toList()),
+                        child: Column(
+                          children: [
+                            widget.mode == CampaignSelectMode.statistics
+                                ? _getCampaignRadioTile(null, theme)
+                                : SizedBox.shrink(),
+                            ..._activeCampaigns.map((c) => _getCampaignRadioTile(c, theme)),
+                          ],
+                        ),
                       ),
                     ),
                   ),
@@ -117,33 +144,37 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
   }
 
   void _closeAndSave() {
-    if (widget.enforceSelect && !_activeCampaigns.isCampaignActive(_selectedCampaignId)) {
+    if (widget.mode == CampaignSelectMode.enforceSelect && !_activeCampaigns.isCampaignActive(_selectedCampaignId)) {
       // Don't allow closing without selection if selection is enforced
       return;
     }
-    var appSettings = GetIt.I<AppSettings>();
-    appSettings.campaign.activeCampaign.recentSelectedCampaignId = _selectedCampaignId;
-    GetIt.I<ActiveCampaignNotifier>().reset();
-
-    Navigator.of(context).pop(true);
+    Navigator.of(context).pop(_selectedCampaignId);
   }
 
-  Widget _getCampaignRadioTile(Campaign c, ThemeData theme) {
+  Widget _getCampaignRadioTile(Campaign? campaign, ThemeData theme) {
+    var campaignId = '-1',
+        campaignName = t.campaigns.statistic.poi_statistics.all_time,
+        campaignSubtitle = t.campaigns.statistic.poi_statistics.all_time_subtitle;
+
+    if (campaign != null) {
+      campaignId = campaign.id;
+      campaignName = campaign.name;
+      campaignSubtitle =
+          '${_activeCampaignDivisions.firstWhere((d) => d.divisionKey == campaign.divisionKey).shortName}, ${t.campaigns.select.electionDate}: ${campaign.electionDate.getAsLocalDateString()}';
+    }
+
     return Container(
       decoration: BoxDecoration(
         border: Border(bottom: BorderSide(width: 0.5, color: ThemeColors.textLight)),
       ),
       child: RadioListTile<String>(
-        value: c.id,
+        value: campaignId,
         fillColor: WidgetStatePropertyAll(ThemeColors.primary),
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(c.name, style: theme.textTheme.labelLarge),
-            Text(
-              '${_activeCampaignDivisions.firstWhere((d) => d.divisionKey == c.divisionKey).shortName}, ${t.campaigns.select.electionDate}: ${c.electionDate.getAsLocalDateString()}',
-              style: theme.textTheme.labelSmall?.apply(color: ThemeColors.textDisabled),
-            ),
+            Text(campaignName, style: theme.textTheme.labelLarge),
+            Text(campaignSubtitle, style: theme.textTheme.labelSmall?.apply(color: ThemeColors.textDisabled)),
           ],
         ),
         visualDensity: VisualDensity(vertical: VisualDensity.minimumDensity, horizontal: VisualDensity.minimumDensity),
@@ -163,32 +194,42 @@ Future<void> showCampaignSelectDialog(BuildContext context, {bool enforceSelect 
 
   final theme = Theme.of(context);
   while (true) {
-    var dialogResult = await showModalBottomSheet<bool>(
+    var selectCampaignResult = await showModalBottomSheet<String>(
       context: context,
       builder: (context) => Padding(
         padding: EdgeInsets.only(bottom: max(MediaQuery.of(context).viewInsets.bottom, DesignConstants.bottomPadding)),
-        child: CampaignSelectWidget(enforceSelect: enforceSelect),
+        child: CampaignSelectWidget(mode: enforceSelect ? CampaignSelectMode.enforceSelect : CampaignSelectMode.normal),
       ),
       isScrollControlled: true,
       isDismissible: isDismissible,
       useRootNavigator: true,
       backgroundColor: theme.colorScheme.surface,
     );
-    if (enforceSelect && (dialogResult == null || dialogResult == false)) {
+    if (enforceSelect && selectCampaignResult == null) {
       // If selection is enforced, we need to show the dialog again if the user dismissed it without selecting
       continue;
     }
+    // apply selection
+    var appSettings = GetIt.I<AppSettings>();
+    appSettings.campaign.activeCampaign.recentSelectedCampaignId = selectCampaignResult;
+    GetIt.I<ActiveCampaignNotifier>().reset();
+
     break;
   }
 }
 
-extension CampaignListExtension on List<Campaign> {
-  List<Campaign> activeCampaigns() {
-    return where((c) => c.status == CampaignStatus.active).toList();
-  }
-
-  bool isCampaignActive(String? campaignId) {
-    if (campaignId == null) return false;
-    return activeCampaigns().any((c) => c.id == campaignId);
-  }
+Future<String?> showCampaignSelectDialogForStatistics(BuildContext context) async {
+  final theme = Theme.of(context);
+  var selectCampaignResult = await showModalBottomSheet<String>(
+    context: context,
+    builder: (context) => Padding(
+      padding: EdgeInsets.only(bottom: max(MediaQuery.of(context).viewInsets.bottom, DesignConstants.bottomPadding)),
+      child: CampaignSelectWidget(mode: CampaignSelectMode.statistics),
+    ),
+    isScrollControlled: true,
+    isDismissible: true,
+    useRootNavigator: true,
+    backgroundColor: theme.colorScheme.surface,
+  );
+  return selectCampaignResult;
 }

--- a/lib/features/campaigns/screens/statistics_screen.dart
+++ b/lib/features/campaigns/screens/statistics_screen.dart
@@ -6,10 +6,12 @@ import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/app/utils/app_settings.dart';
 import 'package:gruene_app/app/utils/logger.dart';
+import 'package:gruene_app/features/campaigns/helper/app_timers.dart';
 import 'package:gruene_app/features/campaigns/models/statistics/campaign_statistics_model.dart';
 import 'package:gruene_app/features/campaigns/screens/badge_statistics_detail.dart';
 import 'package:gruene_app/features/campaigns/screens/poi_statistics_detail.dart';
 import 'package:gruene_app/features/campaigns/screens/team_statistics_detail.dart';
+import 'package:gruene_app/features/campaigns/widgets/statistics_campaign_switcher.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
 class StatisticsScreen extends StatefulWidget {
@@ -24,6 +26,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
   late CampaignStatisticsModel _poiStatistics;
   late TeamStatistics _teamStatistics;
   late TeamMembershipStatistics _teamMembershipStatistics;
+  final _appSettings = GetIt.I<AppSettings>();
 
   @override
   void initState() {
@@ -31,6 +34,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadData();
     });
+    _appSettings.campaign.activeCampaign.addListener(() => reload());
   }
 
   @override
@@ -52,6 +56,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
         physics: AlwaysScrollableScrollPhysics(),
         child: Column(
           children: [
+            StatisticsCampaignSwitcher(),
             BadgeStatisticsDetail(poiStatistics: _poiStatistics),
             TeamStatisticsDetail(teamStatistics: _teamStatistics),
             PoiStatisticsDetail(poiStatistics: _poiStatistics, teamMembershipStatistics: _teamMembershipStatistics),

--- a/lib/features/campaigns/screens/statistics_screen.dart
+++ b/lib/features/campaigns/screens/statistics_screen.dart
@@ -5,8 +5,8 @@ import 'package:gruene_app/app/services/gruene_api_campaigns_statistics_service.
 import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/app/utils/app_settings.dart';
+import 'package:gruene_app/app/utils/campaign.dart';
 import 'package:gruene_app/app/utils/logger.dart';
-import 'package:gruene_app/features/campaigns/helper/app_timers.dart';
 import 'package:gruene_app/features/campaigns/models/statistics/campaign_statistics_model.dart';
 import 'package:gruene_app/features/campaigns/screens/badge_statistics_detail.dart';
 import 'package:gruene_app/features/campaigns/screens/poi_statistics_detail.dart';
@@ -62,7 +62,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
         physics: AlwaysScrollableScrollPhysics(),
         child: Column(
           children: [
-            StatisticsCampaignSwitcher(campaignChanged: () => reload()),
+            StatisticsCampaignSwitcher(campaignChanged: () => reload(overrideCache: true)),
             BadgeStatisticsDetail(poiStatistics: _poiStatistics),
             TeamStatisticsDetail(teamStatistics: _teamStatistics),
             PoiStatisticsDetail(poiStatistics: _poiStatistics, teamMembershipStatistics: _teamMembershipStatistics),
@@ -72,14 +72,18 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     );
   }
 
-  Future<void> reload() async {
-    _loadData();
+  Future<void> reload({bool overrideCache = false}) async {
+    _loadData(overrideCache: overrideCache);
   }
 
-  void _loadData() async {
+  void _loadData({bool overrideCache = false}) async {
     setState(() => _loading = true);
 
-    var results = await Future.wait([_loadPoiStatistics(), _loadTeamStatistics(), _loadOwnTeamStatistics()]);
+    var results = await Future.wait([
+      _loadPoiStatistics(overrideCache: overrideCache),
+      _loadTeamStatistics(overrideCache: overrideCache),
+      _loadOwnTeamStatistics(overrideCache: overrideCache),
+    ]);
 
     var poiCampaignStatistics = results[0] as CampaignStatisticsModel;
     var teamStatistics = results[1] as TeamStatistics;
@@ -93,15 +97,19 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     });
   }
 
-  Future<CampaignStatisticsModel> _loadPoiStatistics() async {
+  Future<CampaignStatisticsModel> _loadPoiStatistics({required bool overrideCache}) async {
     var campaignSettings = GetIt.I<AppSettings>().campaign;
 
-    if (campaignSettings.recentPoiStatistics != null &&
-        DateTime.now().isBefore(campaignSettings.recentPoiStatisticsFetchTimestamp!.add(Duration(minutes: 5)))) {
+    if (!overrideCache &&
+        (campaignSettings.recentPoiStatistics != null &&
+            DateTime.now().isBefore(campaignSettings.recentPoiStatisticsFetchTimestamp!.add(Duration(minutes: 5))))) {
       return campaignSettings.recentPoiStatistics!;
     }
     var statApiService = GetIt.I<GrueneApiCampaignsStatisticsService>();
-    var campaignStatistics = await statApiService.getStatistics();
+    var currentPoiStatisticsCampaignId = getCurrentPoiStatisticsCampaignId();
+    var campaignStatistics = await statApiService.getStatistics(
+      campaigndId: currentPoiStatisticsCampaignId == '-1' ? null : currentPoiStatisticsCampaignId,
+    );
 
     campaignSettings.recentPoiStatistics = campaignStatistics;
     campaignSettings.recentPoiStatisticsFetchTimestamp = DateTime.now();
@@ -109,15 +117,19 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     return campaignStatistics;
   }
 
-  Future<TeamStatistics> _loadTeamStatistics() async {
+  Future<TeamStatistics> _loadTeamStatistics({required bool overrideCache}) async {
     var campaignSettings = GetIt.I<AppSettings>().campaign;
 
-    if (campaignSettings.recentTeamStatistics != null &&
-        DateTime.now().isBefore(campaignSettings.recentTeamStatisticsFetchTimestamp!.add(Duration(minutes: 5)))) {
+    if (!overrideCache &&
+        (campaignSettings.recentTeamStatistics != null &&
+            DateTime.now().isBefore(campaignSettings.recentTeamStatisticsFetchTimestamp!.add(Duration(minutes: 5))))) {
       return campaignSettings.recentTeamStatistics!;
     }
     var teamApiService = GetIt.I<GrueneApiTeamsService>();
-    var teamStats = await teamApiService.getTeamStatistics();
+    var currentPoiStatisticsCampaignId = getCurrentPoiStatisticsCampaignId();
+    var teamStats = await teamApiService.getTeamStatistics(
+      campaignId: currentPoiStatisticsCampaignId == '-1' ? null : currentPoiStatisticsCampaignId,
+    );
 
     campaignSettings.recentTeamStatistics = teamStats;
     campaignSettings.recentTeamStatisticsFetchTimestamp = DateTime.now();
@@ -125,19 +137,23 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     return teamStats;
   }
 
-  Future<TeamMembershipStatistics> _loadOwnTeamStatistics() async {
+  Future<TeamMembershipStatistics> _loadOwnTeamStatistics({required bool overrideCache}) async {
     var campaignSettings = GetIt.I<AppSettings>().campaign;
 
-    if (campaignSettings.recentTeamMembershipStatistics != null &&
-        DateTime.now().isBefore(
-          campaignSettings.recentTeamMembershipStatisticsFetchTimestamp!.add(Duration(minutes: 5)),
-        )) {
+    if (!overrideCache &&
+        (campaignSettings.recentTeamMembershipStatistics != null &&
+            DateTime.now().isBefore(
+              campaignSettings.recentTeamMembershipStatisticsFetchTimestamp!.add(Duration(minutes: 5)),
+            ))) {
       return campaignSettings.recentTeamMembershipStatistics!;
     }
     var teamApiService = GetIt.I<GrueneApiTeamsService>();
 
     try {
-      var teamMembershipStats = await teamApiService.getTeamMembershipStatistics();
+      var currentPoiStatisticsCampaignId = getCurrentPoiStatisticsCampaignId();
+      var teamMembershipStats = await teamApiService.getTeamMembershipStatistics(
+        campaignId: currentPoiStatisticsCampaignId == '-1' ? null : currentPoiStatisticsCampaignId,
+      );
 
       campaignSettings.recentTeamMembershipStatistics = teamMembershipStats;
       campaignSettings.recentTeamMembershipStatisticsFetchTimestamp = DateTime.now();

--- a/lib/features/campaigns/screens/statistics_screen.dart
+++ b/lib/features/campaigns/screens/statistics_screen.dart
@@ -34,7 +34,13 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadData();
     });
-    _appSettings.campaign.activeCampaign.addListener(() => reload());
+    _appSettings.campaign.activeCampaign.addListener(reload);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _appSettings.campaign.activeCampaign.removeListener(reload);
   }
 
   @override
@@ -56,7 +62,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
         physics: AlwaysScrollableScrollPhysics(),
         child: Column(
           children: [
-            StatisticsCampaignSwitcher(),
+            StatisticsCampaignSwitcher(campaignChanged: () => reload()),
             BadgeStatisticsDetail(poiStatistics: _poiStatistics),
             TeamStatisticsDetail(teamStatistics: _teamStatistics),
             PoiStatisticsDetail(poiStatistics: _poiStatistics, teamMembershipStatistics: _teamMembershipStatistics),

--- a/lib/features/campaigns/screens/teams/team_member_statistics.dart
+++ b/lib/features/campaigns/screens/teams/team_member_statistics.dart
@@ -3,6 +3,7 @@ import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/app/utils/campaign.dart';
 import 'package:gruene_app/app/widgets/icon.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
@@ -34,7 +35,7 @@ class _TeamMemberStatisticsState extends State<TeamMemberStatistics> {
     setState(() => _loading = true);
 
     var teamsService = GetIt.I<GrueneApiTeamsService>();
-    var teamStatistics = await teamsService.getTeamMembershipStatistics();
+    var teamStatistics = await teamsService.getTeamMembershipStatistics(campaignId: getCurrentCampaignId() ?? '-1');
 
     setState(() {
       _loading = false;

--- a/lib/features/campaigns/widgets/statistics_campaign_switcher.dart
+++ b/lib/features/campaigns/widgets/statistics_campaign_switcher.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:gruene_app/app/services/gruene_api_campaign_service.dart';
+import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/app/utils/campaign.dart';
+import 'package:gruene_app/i18n/translations.g.dart';
+
+class StatisticsCampaignSwitcher extends StatefulWidget {
+  const StatisticsCampaignSwitcher({super.key});
+
+  @override
+  State<StatisticsCampaignSwitcher> createState() => _StatisticsCampaignSwitcherState();
+}
+
+class _StatisticsCampaignSwitcherState extends State<StatisticsCampaignSwitcher> {
+  String? _currentCampaignName;
+
+  bool _isloading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadData();
+    });
+  }
+
+  Future<void> _loadData() async {
+    setState(() {
+      _isloading = true;
+    });
+
+    var campaignService = GetIt.I<GrueneApiCampaignService>();
+    String? currentCampaignId = getCurrentPoiStatisticsCampaignId();
+    var campaignName = currentCampaignId == null
+        ? t.campaigns.statistic.poi_statistics.all_time
+        : (await campaignService.getCampaign(currentCampaignId)).name;
+
+    setState(() {
+      _isloading = false;
+      _currentCampaignName = campaignName;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var theme = Theme.of(context);
+    return GestureDetector(
+      onTap: () {
+        _selectCampaign();
+      },
+      child: Container(
+        padding: EdgeInsets.fromLTRB(12, 12, 12, 6),
+        decoration: BoxDecoration(color: ThemeColors.background),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  t.campaigns.statistic.poi_statistics.stats_for_campaign,
+                  style: theme.textTheme.labelMedium?.apply(color: ThemeColors.textDisabled),
+                ),
+                Text(
+                  t.common.actions.change,
+                  style: theme.textTheme.labelMedium!.apply(decoration: TextDecoration.underline, fontWeightDelta: 5),
+                ),
+              ],
+            ),
+            _isloading
+                ? Center(child: CircularProgressIndicator())
+                : Row(children: [Text(_currentCampaignName ?? '', style: theme.textTheme.bodyMedium)]),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _selectCampaign() {}
+}

--- a/lib/features/campaigns/widgets/statistics_campaign_switcher.dart
+++ b/lib/features/campaigns/widgets/statistics_campaign_switcher.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/services/gruene_api_campaign_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/app/utils/app_settings.dart';
 import 'package:gruene_app/app/utils/campaign.dart';
+import 'package:gruene_app/features/campaigns/screens/campaign_select_widget.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 
 class StatisticsCampaignSwitcher extends StatefulWidget {
-  const StatisticsCampaignSwitcher({super.key});
+  const StatisticsCampaignSwitcher({super.key, required Future<dynamic> Function() campaignChanged});
 
   @override
   State<StatisticsCampaignSwitcher> createState() => _StatisticsCampaignSwitcherState();
@@ -14,8 +16,8 @@ class StatisticsCampaignSwitcher extends StatefulWidget {
 
 class _StatisticsCampaignSwitcherState extends State<StatisticsCampaignSwitcher> {
   String? _currentCampaignName;
-
   bool _isloading = true;
+  final _appSettings = GetIt.I<AppSettings>();
 
   @override
   void initState() {
@@ -23,6 +25,13 @@ class _StatisticsCampaignSwitcherState extends State<StatisticsCampaignSwitcher>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadData();
     });
+    _appSettings.campaign.activeCampaign.addListener(_loadData);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _appSettings.campaign.activeCampaign.removeListener(_loadData);
   }
 
   Future<void> _loadData() async {
@@ -32,9 +41,11 @@ class _StatisticsCampaignSwitcherState extends State<StatisticsCampaignSwitcher>
 
     var campaignService = GetIt.I<GrueneApiCampaignService>();
     String? currentCampaignId = getCurrentPoiStatisticsCampaignId();
-    var campaignName = currentCampaignId == null
-        ? t.campaigns.statistic.poi_statistics.all_time
-        : (await campaignService.getCampaign(currentCampaignId)).name;
+    var campaignName = switch (currentCampaignId) {
+      null => t.common.unknown,
+      '-1' => t.campaigns.statistic.poi_statistics.all_time,
+      _ => (await campaignService.getCampaign(currentCampaignId)).name,
+    };
 
     setState(() {
       _isloading = false;
@@ -76,5 +87,12 @@ class _StatisticsCampaignSwitcherState extends State<StatisticsCampaignSwitcher>
     );
   }
 
-  void _selectCampaign() {}
+  Future<void> _selectCampaign() async {
+    var selectedCampaignId = await showCampaignSelectDialogForStatistics(context);
+    if (selectedCampaignId != null) {
+      var appSettings = GetIt.I<AppSettings>();
+      appSettings.campaign.recentPoiStatisticsCampaignId = selectedCampaignId;
+      _loadData();
+    }
+  }
 }

--- a/lib/features/campaigns/widgets/statistics_campaign_switcher.dart
+++ b/lib/features/campaigns/widgets/statistics_campaign_switcher.dart
@@ -8,7 +8,9 @@ import 'package:gruene_app/features/campaigns/screens/campaign_select_widget.dar
 import 'package:gruene_app/i18n/translations.g.dart';
 
 class StatisticsCampaignSwitcher extends StatefulWidget {
-  const StatisticsCampaignSwitcher({super.key, required Future<dynamic> Function() campaignChanged});
+  final Future<dynamic> Function() campaignChanged;
+
+  const StatisticsCampaignSwitcher({super.key, required this.campaignChanged});
 
   @override
   State<StatisticsCampaignSwitcher> createState() => _StatisticsCampaignSwitcherState();
@@ -93,6 +95,7 @@ class _StatisticsCampaignSwitcherState extends State<StatisticsCampaignSwitcher>
       var appSettings = GetIt.I<AppSettings>();
       appSettings.campaign.recentPoiStatisticsCampaignId = selectedCampaignId;
       _loadData();
+      widget.campaignChanged();
     }
   }
 }

--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -341,7 +341,9 @@
         "by_my_KV": "von meinem Kreisverband",
         "by_my_LV": "von meinem Landesverband",
         "in_germany": "deutschlandweit",
-        "update_info": "wird alle 5 Minuten aktualisiert"
+        "update_info": "wird alle 5 Minuten aktualisiert",
+        "stats_for_campaign": "Statistiken für",
+        "all_time": "All time"
       },
       "team_statistics": {
         "title": "Team Top-10",

--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -125,7 +125,9 @@
       "title": "Kampagne auswählen",
       "hint": "In welcher Kampagne bist du gerade aktiv? Du kannst die Kampagne jederzeit in deinen Einstellungen ändern.",
       "enforceSelectHint": "Deine bisherige Kampagne '${previousCampaignName}' ist beendet. Bitte wähle eine neue Kampagne aus!",
-      "electionDate": "Wahltermin"
+      "electionDate": "Wahltermin",
+      "statisticsTitle": "Statistik anzeigen",
+      "statisticsHint": "Wähle die Kampagne aus, für die du die Statistiken anzeigen möchtest."
     },
     "infoToast": {
       "focusAreas_activated": "Fokusgebiete aktiviert",
@@ -343,7 +345,8 @@
         "in_germany": "deutschlandweit",
         "update_info": "wird alle 5 Minuten aktualisiert",
         "stats_for_campaign": "Statistiken für",
-        "all_time": "All time"
+        "all_time": "All time",
+        "all_time_subtitle": "Alle Wahlkampf-Aktivitäten ab Januar 2025"
       },
       "team_statistics": {
         "title": "Team Top-10",


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
- Campaign Switcher for stat board in campaign tab
- campaign switcher lets choose between all closed and active campaigns and also a special "all time" campaign
- campaign switcher is reset when new global campaign is switched
- campaign switcher is reused and extended from previous campaign switcher
- campaign switching in stat board reloads stats (overrideCache)

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1010
Fixes: #1011
Fixes: #991

---