### PR TITLE
1068: enforce campaign selection when no campaign selected yet

### DIFF
--- a/lib/features/campaigns/widgets/map_container.dart
+++ b/lib/features/campaigns/widgets/map_container.dart
@@ -22,6 +22,7 @@ import 'package:gruene_app/features/campaigns/helper/map_feature_manager.dart';
 import 'package:gruene_app/features/campaigns/helper/map_helper.dart';
 import 'package:gruene_app/features/campaigns/models/bounding_box.dart';
 import 'package:gruene_app/features/campaigns/models/posters/poster_detail_model.dart';
+import 'package:gruene_app/features/campaigns/screens/campaign_select_widget.dart';
 import 'package:gruene_app/features/campaigns/widgets/campaign_location_button.dart';
 import 'package:gruene_app/features/campaigns/widgets/map_controller.dart';
 import 'package:gruene_app/features/campaigns/widgets/map_controller_simplified.dart';
@@ -150,7 +151,10 @@ class _MapContainerState extends State<MapContainer>
       addMarker = Center(
         child: Container(
           padding: EdgeInsets.only(bottom: 65 /* height of the add_marker icon to position it exactly on the middle */),
-          child: GestureDetector(onTap: _onIconTap, child: SvgPicture.asset(CampaignConstants.addMarkerAssetName)),
+          child: GestureDetector(
+            onTap: _onAddNewPoiMarkerTap,
+            child: SvgPicture.asset(CampaignConstants.addMarkerAssetName),
+          ),
         ),
       );
     }
@@ -235,8 +239,12 @@ class _MapContainerState extends State<MapContainer>
     }
   }
 
-  void _onIconTap() {
+  Future<void> _onAddNewPoiMarkerTap() async {
     final addPOIClicked = widget.addPOIClicked;
+
+    if (appSettings.campaign.activeCampaign.recentSelectedCampaignId == null) {
+      await showCampaignSelectDialog(context, enforceSelect: true);
+    }
 
     if (addPOIClicked != null) {
       addPOIClicked(_controller!.cameraPosition!.target);


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
There might be very small window when a campaign is not set, but to prevent creating POIs when no campaign is selected, we enforce a campaign selection. This should prevent #1068 

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1068 

---