### PR TITLE
1084: Fix profile visibility update fails

### DIFF
--- a/lib/app/services/converters.dart
+++ b/lib/app/services/converters.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' hide Route;
+import 'package:flutter/material.dart' hide Route, Visibility;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/geocode/nominatim.dart';
@@ -41,7 +41,6 @@ import 'package:gruene_app/features/campaigns/models/team/team_assignment.dart';
 import 'package:gruene_app/features/campaigns/widgets/enhanced_wheel_slider.dart';
 import 'package:gruene_app/features/campaigns/widgets/text_input_field.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
-import 'package:gruene_app/swagger_generated_code/gruene_api.enums.swagger.dart' as api_enums;
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 import 'package:intl/intl.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';

--- a/lib/app/services/converters/area_status_parsing.dart
+++ b/lib/app/services/converters/area_status_parsing.dart
@@ -1,12 +1,12 @@
 part of '../converters.dart';
 
 extension AreaStatusParsing on AreaStatus {
-  api_enums.UpdateAreaStatusStatus asUpdateAreaStatusStatus() {
+  AreaStatus asUpdateAreaStatusStatus() {
     switch (this) {
       case AreaStatus.open:
-        return api_enums.UpdateAreaStatusStatus.open;
+        return AreaStatus.open;
       case AreaStatus.closed:
-        return api_enums.UpdateAreaStatusStatus.closed;
+        return AreaStatus.closed;
       case AreaStatus.swaggerGeneratedUnknown:
         throw UnimplementedError();
     }

--- a/lib/app/services/converters/divison_level_extensions.dart
+++ b/lib/app/services/converters/divison_level_extensions.dart
@@ -1,16 +1,16 @@
 part of '../converters.dart';
 
 extension DivisionLevelExtension on DivisionLevel {
-  V1DivisionsGetLevel asV1DivisionsGetLevel() {
+  HierarchyLevel asV1DivisionsGetLevel() {
     switch (this) {
       case DivisionLevel.bv:
-        return V1DivisionsGetLevel.bv;
+        return HierarchyLevel.bv;
       case DivisionLevel.lv:
-        return V1DivisionsGetLevel.lv;
+        return HierarchyLevel.lv;
       case DivisionLevel.kv:
-        return V1DivisionsGetLevel.kv;
+        return HierarchyLevel.kv;
       case DivisionLevel.ov:
-        return V1DivisionsGetLevel.ov;
+        return HierarchyLevel.ov;
       case DivisionLevel.swaggerGeneratedUnknown:
         throw UnimplementedError();
     }

--- a/lib/app/services/converters/new_team_details_parsing.dart
+++ b/lib/app/services/converters/new_team_details_parsing.dart
@@ -12,13 +12,13 @@ extension NewTeamDetailsParsing on NewTeamDetails {
 
   List<CreateTeamMembership> getAllMemberships() {
     var memberships = [
-      ...teamMembers!.map((m) => _asMembership(m, CreateTeamMembershipType.member)),
-      _asMembership(selfJoin ? creatingUser : assignedTeamLead!, CreateTeamMembershipType.lead),
+      ...teamMembers!.map((m) => _asMembership(m, TeamMembershipType.member)),
+      _asMembership(selfJoin ? creatingUser : assignedTeamLead!, TeamMembershipType.lead),
     ];
     return memberships;
   }
 
-  CreateTeamMembership _asMembership(PublicProfile profile, CreateTeamMembershipType membershipType) {
+  CreateTeamMembership _asMembership(PublicProfile profile, TeamMembershipType membershipType) {
     return CreateTeamMembership(userId: profile.userId, type: membershipType);
   }
 }

--- a/lib/app/services/converters/poi_poster_status_parsing.dart
+++ b/lib/app/services/converters/poi_poster_status_parsing.dart
@@ -1,25 +1,25 @@
 part of '../converters.dart';
 
-extension PoiPosterStatusParsing on PoiPosterStatus {
-  PosterStatus transformToModelPosterStatus() {
+extension PoiPosterStatusParsing on PosterStatus {
+  PosterModelStatus transformToModelPosterStatus() {
     return switch (this) {
-      PoiPosterStatus.ok => PosterStatus.ok,
-      PoiPosterStatus.damaged => PosterStatus.damaged,
-      PoiPosterStatus.missing => PosterStatus.missing,
-      PoiPosterStatus.removed => PosterStatus.removed,
-      PoiPosterStatus.toBeMoved => PosterStatus.toBeMoved,
-      PoiPosterStatus.swaggerGeneratedUnknown => throw UnimplementedError(),
+      PosterStatus.ok => PosterModelStatus.ok,
+      PosterStatus.damaged => PosterModelStatus.damaged,
+      PosterStatus.missing => PosterModelStatus.missing,
+      PosterStatus.removed => PosterModelStatus.removed,
+      PosterStatus.toBeMoved => PosterModelStatus.toBeMoved,
+      PosterStatus.swaggerGeneratedUnknown => throw UnimplementedError(),
     };
   }
 
   String translatePosterStatus() {
     return switch (this) {
-      PoiPosterStatus.ok => '',
-      PoiPosterStatus.damaged => t.campaigns.poster.status.damaged.label,
-      PoiPosterStatus.removed => t.campaigns.poster.status.removed.label,
-      PoiPosterStatus.missing => t.campaigns.poster.status.missing.label,
-      PoiPosterStatus.toBeMoved => t.campaigns.poster.status.to_be_moved.label,
-      PoiPosterStatus.swaggerGeneratedUnknown => throw UnimplementedError(),
+      PosterStatus.ok => '',
+      PosterStatus.damaged => t.campaigns.poster.status.damaged.label,
+      PosterStatus.removed => t.campaigns.poster.status.removed.label,
+      PosterStatus.missing => t.campaigns.poster.status.missing.label,
+      PosterStatus.toBeMoved => t.campaigns.poster.status.to_be_moved.label,
+      PosterStatus.swaggerGeneratedUnknown => throw UnimplementedError(),
     };
   }
 }

--- a/lib/app/services/converters/poi_service_type_parsing.dart
+++ b/lib/app/services/converters/poi_service_type_parsing.dart
@@ -45,36 +45,36 @@ extension PoiCacheTypeParsing on PoiCacheType {
 }
 
 extension PoiServiceTypeParsing on PoiServiceType {
-  V1CampaignsPoisGetType transformToApiPoisGetType() {
+  PoiType transformToApiPoisGetType() {
     switch (this) {
       case PoiServiceType.poster:
-        return V1CampaignsPoisGetType.poster;
+        return PoiType.poster;
       case PoiServiceType.door:
-        return V1CampaignsPoisGetType.house;
+        return PoiType.house;
       case PoiServiceType.flyer:
-        return V1CampaignsPoisGetType.flyerSpot;
+        return PoiType.flyerSpot;
     }
   }
 
-  V1CampaignsPoisSelfGetType transformToApiPoisSelfGetType() {
+  PoiType transformToApiPoisSelfGetType() {
     switch (this) {
       case PoiServiceType.poster:
-        return V1CampaignsPoisSelfGetType.poster;
+        return PoiType.poster;
       case PoiServiceType.door:
-        return V1CampaignsPoisSelfGetType.house;
+        return PoiType.house;
       case PoiServiceType.flyer:
-        return V1CampaignsPoisSelfGetType.flyerSpot;
+        return PoiType.flyerSpot;
     }
   }
 
-  CreatePoiType transformToApiCreatePoiType() {
+  PoiType transformToApiCreatePoiType() {
     switch (this) {
       case PoiServiceType.poster:
-        return CreatePoiType.poster;
+        return PoiType.poster;
       case PoiServiceType.door:
-        return CreatePoiType.house;
+        return PoiType.house;
       case PoiServiceType.flyer:
-        return CreatePoiType.flyerSpot;
+        return PoiType.flyerSpot;
     }
   }
 
@@ -89,7 +89,7 @@ extension PoiServiceTypeParsing on PoiServiceType {
     }
   }
 
-  String getAsMarkerItemStatus(PosterStatus? posterStatus) {
+  String getAsMarkerItemStatus(PosterModelStatus? posterStatus) {
     var typeName = name;
     switch (this) {
       case PoiServiceType.poster:

--- a/lib/app/services/converters/poi_service_type_parsing.dart
+++ b/lib/app/services/converters/poi_service_type_parsing.dart
@@ -45,29 +45,7 @@ extension PoiCacheTypeParsing on PoiCacheType {
 }
 
 extension PoiServiceTypeParsing on PoiServiceType {
-  PoiType transformToApiPoisGetType() {
-    switch (this) {
-      case PoiServiceType.poster:
-        return PoiType.poster;
-      case PoiServiceType.door:
-        return PoiType.house;
-      case PoiServiceType.flyer:
-        return PoiType.flyerSpot;
-    }
-  }
-
-  PoiType transformToApiPoisSelfGetType() {
-    switch (this) {
-      case PoiServiceType.poster:
-        return PoiType.poster;
-      case PoiServiceType.door:
-        return PoiType.house;
-      case PoiServiceType.flyer:
-        return PoiType.flyerSpot;
-    }
-  }
-
-  PoiType transformToApiCreatePoiType() {
+  PoiType transformToApiPoisType() {
     switch (this) {
       case PoiServiceType.poster:
         return PoiType.poster;

--- a/lib/app/services/converters/poster_create_model_parsing.dart
+++ b/lib/app/services/converters/poster_create_model_parsing.dart
@@ -4,7 +4,7 @@ extension PosterCreateModelParsing on PosterCreateModel {
   PoiDetailModel transformToVirtualPoiDetailModel(int temporaryId) {
     return PoiDetailModel.virtual(
       id: temporaryId,
-      status: PoiServiceType.poster.getAsMarkerItemStatus(PosterStatus.ok),
+      status: PoiServiceType.poster.getAsMarkerItemStatus(PosterModelStatus.ok),
       location: location,
     );
   }
@@ -12,7 +12,7 @@ extension PosterCreateModelParsing on PosterCreateModel {
   PosterDetailModel transformToPosterDetailModel(String temporaryId) {
     return PosterDetailModel(
       id: temporaryId,
-      status: PosterStatus.ok,
+      status: PosterModelStatus.ok,
       address: address,
       photos: imageFileLocation == null
           ? []

--- a/lib/app/services/converters/poster_status_parsing.dart
+++ b/lib/app/services/converters/poster_status_parsing.dart
@@ -1,13 +1,13 @@
 part of '../converters.dart';
 
-extension PosterStatusParsing on PosterStatus {
-  PoiPosterStatus transformToPoiPosterStatus() {
+extension PosterStatusParsing on PosterModelStatus {
+  PosterStatus transformToPoiPosterStatus() {
     return switch (this) {
-      PosterStatus.ok => PoiPosterStatus.ok,
-      PosterStatus.damaged => PoiPosterStatus.damaged,
-      PosterStatus.missing => PoiPosterStatus.missing,
-      PosterStatus.removed => PoiPosterStatus.removed,
-      PosterStatus.toBeMoved => PoiPosterStatus.toBeMoved,
+      PosterModelStatus.ok => PosterStatus.ok,
+      PosterModelStatus.damaged => PosterStatus.damaged,
+      PosterModelStatus.missing => PosterStatus.missing,
+      PosterModelStatus.removed => PosterStatus.removed,
+      PosterModelStatus.toBeMoved => PosterStatus.toBeMoved,
     };
   }
 

--- a/lib/app/services/converters/profile_extension.dart
+++ b/lib/app/services/converters/profile_extension.dart
@@ -3,22 +3,22 @@ part of '../converters.dart';
 extension ProfileExtension on Profile {
   bool isVisibleInKV() {
     switch (privacy.overall) {
-      case ProfilePrivacySettingsOverall.private:
-      case ProfilePrivacySettingsOverall.ovWide:
+      case Visibility.private:
+      case Visibility.ovWide:
         return false;
-      case ProfilePrivacySettingsOverall.kvWide:
-      case ProfilePrivacySettingsOverall.public:
-      case ProfilePrivacySettingsOverall.lvWide:
-      case ProfilePrivacySettingsOverall.bvWide:
+      case Visibility.kvWide:
+      case Visibility.public:
+      case Visibility.lvWide:
+      case Visibility.bvWide:
         return true;
-      case ProfilePrivacySettingsOverall.swaggerGeneratedUnknown:
+      case Visibility.swaggerGeneratedUnknown:
         throw UnimplementedError();
     }
   }
 
   Future<Division?> getOwnKV() async {
     var division = memberships
-        ?.firstWhereOrNull((d) => [DivisionLevel.kv, DivisionLevel.ov].contains(d.division.level))
+        .firstWhereOrNull((d) => [DivisionLevel.kv, DivisionLevel.ov].contains(d.division.level))
         ?.division;
 
     switch (division?.level) {

--- a/lib/app/services/converters/route_type_parsing.dart
+++ b/lib/app/services/converters/route_type_parsing.dart
@@ -11,14 +11,14 @@ extension TeamRouteTypeParsing on RouteType {
     return '$typeLabel-${t.campaigns.route.label}';
   }
 
-  UpdateRouteType asUpdateRouteType() {
+  RouteType asUpdateRouteType() {
     switch (this) {
       case RouteType.flyerSpot:
-        return UpdateRouteType.flyerSpot;
+        return RouteType.flyerSpot;
       case RouteType.poster:
-        return UpdateRouteType.poster;
+        return RouteType.poster;
       case RouteType.house:
-        return UpdateRouteType.house;
+        return RouteType.house;
 
       case RouteType.swaggerGeneratedUnknown:
         throw UnimplementedError();
@@ -27,12 +27,12 @@ extension TeamRouteTypeParsing on RouteType {
 }
 
 extension TeamRouteStatusParsing on RouteStatus {
-  api_enums.UpdateRouteStatusStatus asUpdateRouteStatusStatus() {
+  RouteStatus asUpdateRouteStatusStatus() {
     switch (this) {
       case RouteStatus.open:
-        return api_enums.UpdateRouteStatusStatus.open;
+        return RouteStatus.open;
       case RouteStatus.closed:
-        return api_enums.UpdateRouteStatusStatus.closed;
+        return RouteStatus.closed;
 
       case RouteStatus.swaggerGeneratedUnknown:
         throw UnimplementedError();

--- a/lib/app/services/converters/team_membership_type_parsing.dart
+++ b/lib/app/services/converters/team_membership_type_parsing.dart
@@ -1,12 +1,12 @@
 part of '../converters.dart';
 
 extension TeamMembershipTypeParsing on TeamMembershipType {
-  UpdateTeamMembershipType asUpdateTeamMembershipType() {
+  TeamMembershipType asUpdateTeamMembershipType() {
     switch (this) {
       case TeamMembershipType.lead:
-        return UpdateTeamMembershipType.lead;
+        return TeamMembershipType.lead;
       case TeamMembershipType.member:
-        return UpdateTeamMembershipType.member;
+        return TeamMembershipType.member;
       case TeamMembershipType.swaggerGeneratedUnknown:
         throw UnimplementedError();
     }

--- a/lib/app/services/gruene_api_campaigns_base_service.dart
+++ b/lib/app/services/gruene_api_campaigns_base_service.dart
@@ -95,7 +95,7 @@ abstract class GrueneApiCampaignsPoiBaseService extends GrueneApiBaseService {
 
     if (poi.createdAt.millisecondsSinceEpoch > Config.poiFilterCutOffDate!.millisecondsSinceEpoch) return true;
 
-    if (poi.type == PoiType.poster && poi.poster!.status == PoiPosterStatus.ok) {
+    if (poi.type == PoiType.poster && poi.poster!.status == PosterStatus.ok) {
       return true;
     }
 

--- a/lib/app/services/gruene_api_campaigns_base_service.dart
+++ b/lib/app/services/gruene_api_campaigns_base_service.dart
@@ -16,7 +16,7 @@ abstract class GrueneApiCampaignsPoiBaseService extends GrueneApiBaseService {
   Future<List<PoiDetailModel>> loadPoisInRegion(String campaignId, LatLng locationSW, LatLng locationNE) async =>
       getFromApi(
         apiRequest: (api) => api.v1CampaignsPoisGet(
-          type: poiType.transformToApiPoisGetType(),
+          type: poiType.transformToApiPoisType(),
           bbox: locationSW.transformToGeoJsonBBoxString(locationNE),
           campaignId: [campaignId],
         ),

--- a/lib/app/services/gruene_api_door_service.dart
+++ b/lib/app/services/gruene_api_door_service.dart
@@ -15,7 +15,7 @@ class GrueneApiDoorService extends GrueneApiCampaignsPoiBaseService {
       body: CreatePoi(
         campaignId: newDoor.campaignId,
         coords: newDoor.location.transformToGeoJsonCoords(),
-        type: poiType.transformToApiCreatePoiType(),
+        type: poiType.transformToApiPoisType(),
         address: newDoor.address.transformToPoiAddress(),
         house: PoiHouse(
           countOpenedDoors: newDoor.openedDoors.toDouble(),

--- a/lib/app/services/gruene_api_flyer_service.dart
+++ b/lib/app/services/gruene_api_flyer_service.dart
@@ -15,7 +15,7 @@ class GrueneApiFlyerService extends GrueneApiCampaignsPoiBaseService {
       body: CreatePoi(
         campaignId: newFlyer.campaignId,
         coords: newFlyer.location.transformToGeoJsonCoords(),
-        type: poiType.transformToApiCreatePoiType(),
+        type: poiType.transformToApiPoisType(),
         address: newFlyer.address.transformToPoiAddress(),
         flyerSpot: PoiFlyerSpot(flyerCount: newFlyer.flyerCount.toDouble()),
       ),

--- a/lib/app/services/gruene_api_poster_service.dart
+++ b/lib/app/services/gruene_api_poster_service.dart
@@ -21,7 +21,7 @@ class GrueneApiPosterService extends GrueneApiCampaignsPoiBaseService {
     final requestParam = CreatePoi(
       campaignId: newPoster.campaignId,
       coords: newPoster.location.transformToGeoJsonCoords(),
-      type: poiType.transformToApiCreatePoiType(),
+      type: poiType.transformToApiPoisType(),
       address: newPoster.address.transformToPoiAddress(),
     );
     // saving POI
@@ -89,8 +89,7 @@ class GrueneApiPosterService extends GrueneApiCampaignsPoiBaseService {
   }
 
   Future<List<PosterListItemModel>> getMyPosters(String campaignId) async => getFromApi(
-    apiRequest: (api) =>
-        api.v1CampaignsPoisSelfGet(type: poiType.transformToApiPoisSelfGetType(), campaignId: [campaignId]),
+    apiRequest: (api) => api.v1CampaignsPoisSelfGet(type: poiType.transformToApiPoisType(), campaignId: [campaignId]),
     map: (result) => result.data.where(filterByCutOffDate).map((p) => p.transformToPosterListItem()).toList(),
   );
 }

--- a/lib/app/services/gruene_api_profile_service.dart
+++ b/lib/app/services/gruene_api_profile_service.dart
@@ -13,9 +13,4 @@ class GrueneApiProfileService extends GrueneApiBaseService {
       getFromApi(apiRequest: (api) => api.v1ProfilesProfileIdGet(profileId: profileId));
 
   Future<Profile> getOwnProfile() async => getFromApi(apiRequest: (api) => api.v1ProfilesSelfGet());
-
-  Future<Profile> updateProfile(Profile profile) async => getFromApi(
-    apiRequest: (api) =>
-        api.v1ProfilesProfileIdPut(profileId: profile.id, body: UpdateProfile.fromJson(profile.toJson())),
-  );
 }

--- a/lib/app/services/gruene_api_profile_service.dart
+++ b/lib/app/services/gruene_api_profile_service.dart
@@ -11,6 +11,4 @@ class GrueneApiProfileService extends GrueneApiBaseService {
 
   Future<PublicProfile> getProfile(String profileId) async =>
       getFromApi(apiRequest: (api) => api.v1ProfilesProfileIdGet(profileId: profileId));
-
-  Future<Profile> getOwnProfile() async => getFromApi(apiRequest: (api) => api.v1ProfilesSelfGet());
 }

--- a/lib/app/services/gruene_api_teams_service.dart
+++ b/lib/app/services/gruene_api_teams_service.dart
@@ -26,21 +26,21 @@ class GrueneApiTeamsService extends GrueneApiBaseService {
   Future<Team> acceptTeamMembership(String teamId) async => getFromApi(
     apiRequest: (api) => api.v1CampaignsTeamsTeamIdMembershipStatusPut(
       teamId: teamId,
-      body: UpdateTeamMembershipStatus(type: UpdateTeamMembershipStatusType.accept),
+      body: UpdateTeamMembershipStatus(type: TeamMembershipStatusUpdateType.accept),
     ),
   );
 
   Future<Team> rejectTeamMembership(String teamId) async => getFromApi(
     apiRequest: (api) => api.v1CampaignsTeamsTeamIdMembershipStatusPut(
       teamId: teamId,
-      body: UpdateTeamMembershipStatus(type: UpdateTeamMembershipStatusType.reject),
+      body: UpdateTeamMembershipStatus(type: TeamMembershipStatusUpdateType.reject),
     ),
   );
 
   Future<Team> leaveTeam(String teamId) async => getFromApi(
     apiRequest: (api) => api.v1CampaignsTeamsTeamIdMembershipStatusPut(
       teamId: teamId,
-      body: UpdateTeamMembershipStatus(type: UpdateTeamMembershipStatusType.resign),
+      body: UpdateTeamMembershipStatus(type: TeamMembershipStatusUpdateType.resign),
     ),
   );
 
@@ -50,7 +50,7 @@ class GrueneApiTeamsService extends GrueneApiBaseService {
   Future<Team> addTeamMembership({required String teamId, required String userId}) => getFromApi(
     apiRequest: (api) => api.v1CampaignsTeamsTeamIdMembershipPost(
       teamId: teamId,
-      body: CreateTeamMembership(type: CreateTeamMembershipType.member, userId: userId),
+      body: CreateTeamMembership(type: TeamMembershipType.member, userId: userId),
     ),
   );
 

--- a/lib/app/utils/profile.dart
+++ b/lib/app/utils/profile.dart
@@ -22,4 +22,37 @@ extension MembershipsExtension on Profile {
     ProfilePrivacySettingsOverall.bvWide,
     ProfilePrivacySettingsOverall.public,
   ];
+
+  UpdateProfile get updateProfile => UpdateProfile(
+    email: email,
+    phoneNumbers: phoneNumbers
+        .map((number) => UpdatePhoneNumber(id: number.id, country: number.country, number: number.number))
+        .toList(),
+    messengers: messengers
+        .map(
+          (messenger) => UpdateMessengerEntry(
+            id: messenger.id,
+            externalId: messenger.externalId,
+            type: UpdateMessengerEntryType.values.firstWhere(
+              (type) => type.value == messenger.type.value,
+              orElse: () => UpdateMessengerEntryType.swaggerGeneratedUnknown,
+            ),
+          ),
+        )
+        .toList(),
+    socialMedia: socialMedia
+        .map(
+          (socialMedia) => UpdateSocialMediaEntry(
+            id: socialMedia.id,
+            url: socialMedia.url,
+            type: UpdateSocialMediaEntryType.values.firstWhere(
+              (type) => type.value == socialMedia.type.value,
+              orElse: () => UpdateSocialMediaEntryType.swaggerGeneratedUnknown,
+            ),
+          ),
+        )
+        .toList(),
+    tags: tags.map((tag) => tag.externalId!).toList(),
+    privacy: privacy,
+  );
 }

--- a/lib/app/utils/profile.dart
+++ b/lib/app/utils/profile.dart
@@ -2,7 +2,7 @@ import 'package:gruene_app/app/utils/utils.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
 extension MembershipsExtension on Profile {
-  List<Division> divisions() => memberships?.map((membership) => membership.division).toList() ?? [];
+  List<Division> divisions() => memberships.map((membership) => membership.division).toList();
 
   Division? partyDivision() => divisions().firstWhereOrNull((division) => division.hierarchy == 'GR');
 
@@ -12,15 +12,15 @@ extension MembershipsExtension on Profile {
 
   // TODO #1065: Adjust to OV if teams are available for OVs and user is in an OV
   // ProfilePrivacySettingsOverall minTeamVisibilityOption() => profileVisibilityOptions()[2];
-  ProfilePrivacySettingsOverall minTeamVisibilityOption() => ProfilePrivacySettingsOverall.kvWide;
+  Visibility minTeamVisibilityOption() => Visibility.kvWide;
 
-  List<ProfilePrivacySettingsOverall> profileVisibilityOptions() => [
-    ProfilePrivacySettingsOverall.private,
-    ...(partyDivision()?.level == DivisionLevel.ov ? [ProfilePrivacySettingsOverall.ovWide] : []),
-    ProfilePrivacySettingsOverall.kvWide,
-    ProfilePrivacySettingsOverall.lvWide,
-    ProfilePrivacySettingsOverall.bvWide,
-    ProfilePrivacySettingsOverall.public,
+  List<Visibility> profileVisibilityOptions() => [
+    Visibility.private,
+    ...(partyDivision()?.level == DivisionLevel.ov ? [Visibility.ovWide] : []),
+    Visibility.kvWide,
+    Visibility.lvWide,
+    Visibility.bvWide,
+    Visibility.public,
   ];
 
   UpdateProfile get updateProfile => UpdateProfile(
@@ -30,27 +30,11 @@ extension MembershipsExtension on Profile {
         .toList(),
     messengers: messengers
         .map(
-          (messenger) => UpdateMessengerEntry(
-            id: messenger.id,
-            externalId: messenger.externalId,
-            type: UpdateMessengerEntryType.values.firstWhere(
-              (type) => type.value == messenger.type.value,
-              orElse: () => UpdateMessengerEntryType.swaggerGeneratedUnknown,
-            ),
-          ),
+          (messenger) => UpdateMessengerEntry(id: messenger.id, externalId: messenger.externalId, type: messenger.type),
         )
         .toList(),
     socialMedia: socialMedia
-        .map(
-          (socialMedia) => UpdateSocialMediaEntry(
-            id: socialMedia.id,
-            url: socialMedia.url,
-            type: UpdateSocialMediaEntryType.values.firstWhere(
-              (type) => type.value == socialMedia.type.value,
-              orElse: () => UpdateSocialMediaEntryType.swaggerGeneratedUnknown,
-            ),
-          ),
-        )
+        .map((socialMedia) => UpdateSocialMediaEntry(id: socialMedia.id, url: socialMedia.url, type: socialMedia.type))
         .toList(),
     tags: tags.map((tag) => tag.externalId!).toList(),
     privacy: privacy,

--- a/lib/features/campaigns/helper/poster_status.dart
+++ b/lib/features/campaigns/helper/poster_status.dart
@@ -2,11 +2,11 @@ import 'package:gruene_app/features/campaigns/models/posters/poster_detail_model
 import 'package:gruene_app/i18n/translations.g.dart';
 
 class PosterStatusHelper {
-  static List<(PosterStatus, String)> getPosterStatusList = <(PosterStatus status, String label)>[
-    (PosterStatus.ok, t.campaigns.poster.status.ok.label),
-    (PosterStatus.damaged, t.campaigns.poster.status.damaged.label),
-    (PosterStatus.missing, t.campaigns.poster.status.missing.label),
-    (PosterStatus.toBeMoved, t.campaigns.poster.status.to_be_moved.label),
-    (PosterStatus.removed, t.campaigns.poster.status.removed.label),
+  static List<(PosterModelStatus, String)> getPosterStatusList = <(PosterModelStatus status, String label)>[
+    (PosterModelStatus.ok, t.campaigns.poster.status.ok.label),
+    (PosterModelStatus.damaged, t.campaigns.poster.status.damaged.label),
+    (PosterModelStatus.missing, t.campaigns.poster.status.missing.label),
+    (PosterModelStatus.toBeMoved, t.campaigns.poster.status.to_be_moved.label),
+    (PosterModelStatus.removed, t.campaigns.poster.status.removed.label),
   ];
 }

--- a/lib/features/campaigns/helper/profile_search_helper.dart
+++ b/lib/features/campaigns/helper/profile_search_helper.dart
@@ -84,7 +84,7 @@ class ProfileSearchHelper {
                       child: Align(
                         alignment: Alignment.centerLeft,
                         child: Text(
-                          item.memberships!.map((m) => m.division.shortName).join(', '),
+                          item.memberships.map((m) => m.division.shortName).join(', '),
                           style: theme.textTheme.bodyMedium,
                         ),
                       ),

--- a/lib/features/campaigns/models/posters/poster_detail_model.dart
+++ b/lib/features/campaigns/models/posters/poster_detail_model.dart
@@ -7,7 +7,7 @@ import 'package:maplibre_gl/maplibre_gl.dart';
 
 part 'poster_detail_model.g.dart';
 
-enum PosterStatus {
+enum PosterModelStatus {
   @JsonValue(100)
   ok,
   @JsonValue(200)
@@ -29,7 +29,7 @@ class PosterDetailModel implements BasicPoi {
   @override
   final AddressModel address;
   final String comment;
-  final PosterStatus status;
+  final PosterModelStatus status;
   final String createdAt;
   final bool isCached;
   @LatLongConverter()
@@ -51,7 +51,7 @@ class PosterDetailModel implements BasicPoi {
     List<PosterPhotoModel>? photos,
     AddressModel? address,
     String? comment,
-    PosterStatus? status,
+    PosterModelStatus? status,
     String? createdAt,
     bool? isCached,
     LatLng? location,

--- a/lib/features/campaigns/models/posters/poster_update_model.dart
+++ b/lib/features/campaigns/models/posters/poster_update_model.dart
@@ -11,7 +11,7 @@ part 'poster_update_model.g.dart';
 class PosterUpdateModel {
   final String id;
   final AddressModel address;
-  final PosterStatus status;
+  final PosterModelStatus status;
   final String comment;
   @LatLongConverter()
   final LatLng location;
@@ -37,7 +37,7 @@ class PosterUpdateModel {
   PosterUpdateModel copyWith({
     String? id,
     AddressModel? address,
-    PosterStatus? status,
+    PosterModelStatus? status,
     String? comment,
     LatLng? location,
     List<String>? deletedPhotoIds,

--- a/lib/features/campaigns/screens/campaign_select_widget.dart
+++ b/lib/features/campaigns/screens/campaign_select_widget.dart
@@ -80,7 +80,7 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
         selectableCampaigns.isNotEmpty) {
       var profileService = GetIt.I<GrueneApiProfileService>();
       var currentProfile = await profileService.getSelf();
-      var userDivisionKeys = (currentProfile.memberships ?? []).map((m) => m.division.divisionKey).toList();
+      var userDivisionKeys = (currentProfile.memberships).map((m) => m.division.divisionKey).toList();
       var preSelectCandidates = selectableCampaigns
           .where((c) => userDivisionKeys.any((d) => d.startsWith(c.divisionKey.stripRight('0'))))
           .map((c) => c.id)

--- a/lib/features/campaigns/screens/poster_detail.dart
+++ b/lib/features/campaigns/screens/poster_detail.dart
@@ -21,24 +21,24 @@ class PosterDetail extends StatelessWidget {
   Widget build(BuildContext context) {
     getStatusColor() {
       switch (poi.status) {
-        case PosterStatus.ok:
+        case PosterModelStatus.ok:
           return ThemeColors.secondary;
-        case PosterStatus.damaged:
-        case PosterStatus.missing:
-        case PosterStatus.toBeMoved:
+        case PosterModelStatus.damaged:
+        case PosterModelStatus.missing:
+        case PosterModelStatus.toBeMoved:
           return Colors.red;
-        case PosterStatus.removed:
+        case PosterModelStatus.removed:
           return ThemeColors.textDisabled;
       }
     }
 
     getStatusText() {
       return switch (poi.status) {
-        PosterStatus.ok => t.campaigns.poster.status.ok.description,
-        PosterStatus.damaged => t.campaigns.poster.status.damaged.description,
-        PosterStatus.missing => t.campaigns.poster.status.missing.description,
-        PosterStatus.toBeMoved => t.campaigns.poster.status.to_be_moved.description,
-        PosterStatus.removed => t.campaigns.poster.status.removed.description,
+        PosterModelStatus.ok => t.campaigns.poster.status.ok.description,
+        PosterModelStatus.damaged => t.campaigns.poster.status.damaged.description,
+        PosterModelStatus.missing => t.campaigns.poster.status.missing.description,
+        PosterModelStatus.toBeMoved => t.campaigns.poster.status.to_be_moved.description,
+        PosterModelStatus.removed => t.campaigns.poster.status.removed.description,
       };
     }
 
@@ -46,7 +46,7 @@ class PosterDetail extends StatelessWidget {
 
     var widgetHeight = 250.0;
     var extraRows = <Widget>[];
-    if (poi.status != PosterStatus.removed) {
+    if (poi.status != PosterModelStatus.removed) {
       // set extra height for additional button
       widgetHeight += 55;
       extraRows.add(
@@ -153,7 +153,7 @@ class PosterDetail extends StatelessWidget {
 
   void onPosterRemoved(BuildContext context) {
     var oldStatus = poi.status;
-    var poiUpdate = poi.asPosterUpdate().copyWith(status: PosterStatus.removed);
+    var poiUpdate = poi.asPosterUpdate().copyWith(status: PosterModelStatus.removed);
     onSave(poiUpdate);
     _closeDialog(context);
 

--- a/lib/features/campaigns/screens/poster_edit.dart
+++ b/lib/features/campaigns/screens/poster_edit.dart
@@ -427,11 +427,11 @@ class _PosterEditState extends State<PosterEdit> with AddressExtension, ConfirmD
     });
   }
 
-  PosterStatus _selectedPosterStatus = PosterStatus.ok;
+  PosterModelStatus _selectedPosterStatus = PosterModelStatus.ok;
 
-  Widget _getRadioItem((PosterStatus, String) item) {
+  Widget _getRadioItem((PosterModelStatus, String) item) {
     var theme = Theme.of(context);
-    return RadioListTile<PosterStatus>(
+    return RadioListTile<PosterModelStatus>(
       value: item.$1,
       fillColor: WidgetStatePropertyAll(ThemeColors.primary),
       title: Text(item.$2, style: theme.textTheme.bodyMedium),

--- a/lib/features/campaigns/screens/teams/new_team_basic_info_widget.dart
+++ b/lib/features/campaigns/screens/teams/new_team_basic_info_widget.dart
@@ -115,6 +115,7 @@ class _NewTeamBasicInfoWidgetState extends State<NewTeamBasicInfoWidget> {
         tags: [],
         roles: [],
         achievements: [],
+        memberships: [],
       );
     } catch (e) {
       var userService = GetIt.I<GrueneApiUserService>();
@@ -132,6 +133,7 @@ class _NewTeamBasicInfoWidgetState extends State<NewTeamBasicInfoWidget> {
         tags: [],
         roles: [],
         achievements: [],
+        memberships: [],
       );
     }
   }

--- a/lib/features/events/widgets/event_edit_dialog.dart
+++ b/lib/features/events/widgets/event_edit_dialog.dart
@@ -17,7 +17,7 @@ import 'package:gruene_app/features/events/domain/events_api_service.dart';
 import 'package:gruene_app/features/events/utils/utils.dart';
 import 'package:gruene_app/features/events/widgets/event_recurrence_form.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
-import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
+import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart' hide Visibility;
 import 'package:intl/intl.dart';
 import 'package:rrule/rrule.dart';
 

--- a/lib/features/events/widgets/event_recurrence_form.dart
+++ b/lib/features/events/widgets/event_recurrence_form.dart
@@ -7,7 +7,7 @@ import 'package:gruene_app/app/widgets/form_section.dart';
 import 'package:gruene_app/features/events/utils/utils.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/main.dart';
-import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
+import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart' hide Visibility;
 import 'package:intl/intl.dart';
 import 'package:rrule/rrule.dart';
 

--- a/lib/features/news/domain/bookmark_service.dart
+++ b/lib/features/news/domain/bookmark_service.dart
@@ -6,7 +6,7 @@ Future<List<Bookmark>> fetchBookmarks() async =>
 
 Future<void> createBookmark(String newsId) async => postToApi(
   request: (api) => api.v1BookmarksPost(
-    body: CreateBookmark(type: createBookmarkTypeFromJson(BookmarkType.news.value), itemId: newsId),
+    body: CreateBookmark(type: BookmarkType.news, itemId: newsId),
   ),
 );
 

--- a/lib/features/profiles/domain/profiles_api_service.dart
+++ b/lib/features/profiles/domain/profiles_api_service.dart
@@ -1,8 +1,13 @@
 import 'package:gruene_app/app/services/gruene_api_core.dart';
+import 'package:gruene_app/app/utils/profile.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 import 'package:http/http.dart';
 
 Future<Profile> fetchOwnProfile() async => getFromApi(request: (api) => api.v1ProfilesSelfGet(), map: (data) => data);
+
+Future<Profile> updateProfile(Profile profile) async => getFromApi(
+  request: (api) => api.v1ProfilesProfileIdPut(profileId: profile.id, body: profile.updateProfile),
+);
 
 Future<Profile> updateProfileImage({required String profileId, required MultipartFile profileImage}) async =>
     getFromApi(

--- a/lib/features/profiles/screens/own_profile_screen.dart
+++ b/lib/features/profiles/screens/own_profile_screen.dart
@@ -63,10 +63,10 @@ class OwnProfileScreen extends StatelessWidget {
                     ProfileCardListItem(title: t.profiles.personalId, value: profile.personalId, copyOnTap: true),
                   ],
                 ),
-                if (profile.memberships?.isNotEmpty ?? false)
+                if (profile.memberships.isNotEmpty)
                   ProfileCard(
                     title: t.profiles.memberships,
-                    children: profile.memberships!
+                    children: profile.memberships
                         .map(
                           (membership) =>
                               ProfileCardListItem(value: '${membership.division.name1} ${membership.division.name2}'),

--- a/lib/features/profiles/utils/profile_visibility.dart
+++ b/lib/features/profiles/utils/profile_visibility.dart
@@ -1,27 +1,27 @@
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.enums.swagger.dart';
 
-String visibilityLabel(ProfilePrivacySettingsOverall visibility) => switch (visibility) {
-  ProfilePrivacySettingsOverall.private => t.profiles.visibility.private,
-  ProfilePrivacySettingsOverall.ovWide => t.divisions.level.ov.label,
-  ProfilePrivacySettingsOverall.kvWide => t.divisions.level.kv.label,
-  ProfilePrivacySettingsOverall.lvWide => t.divisions.level.lv.label,
-  ProfilePrivacySettingsOverall.bvWide => t.divisions.level.bv.label,
-  ProfilePrivacySettingsOverall.public => t.profiles.visibility.public,
+String visibilityLabel(Visibility visibility) => switch (visibility) {
+  Visibility.private => t.profiles.visibility.private,
+  Visibility.ovWide => t.divisions.level.ov.label,
+  Visibility.kvWide => t.divisions.level.kv.label,
+  Visibility.lvWide => t.divisions.level.lv.label,
+  Visibility.bvWide => t.divisions.level.bv.label,
+  Visibility.public => t.profiles.visibility.public,
   _ => '',
 };
 
-String visibilityShortLabel(ProfilePrivacySettingsOverall visibility) => switch (visibility) {
-  ProfilePrivacySettingsOverall.ovWide => t.divisions.level.ov.short,
-  ProfilePrivacySettingsOverall.kvWide => t.divisions.level.kv.short,
-  ProfilePrivacySettingsOverall.lvWide => t.divisions.level.lv.short,
-  ProfilePrivacySettingsOverall.bvWide => t.divisions.level.bv.short,
+String visibilityShortLabel(Visibility visibility) => switch (visibility) {
+  Visibility.ovWide => t.divisions.level.ov.short,
+  Visibility.kvWide => t.divisions.level.kv.short,
+  Visibility.lvWide => t.divisions.level.lv.short,
+  Visibility.bvWide => t.divisions.level.bv.short,
   _ => visibilityLabel(visibility),
 };
 
-String visibilityHint(ProfilePrivacySettingsOverall visibility) => switch (visibility) {
-  ProfilePrivacySettingsOverall.private => t.profiles.visibility.privateHint,
-  ProfilePrivacySettingsOverall.ovWide => t.profiles.visibility.ovHint,
-  ProfilePrivacySettingsOverall.public => t.profiles.visibility.publicHint,
+String visibilityHint(Visibility visibility) => switch (visibility) {
+  Visibility.private => t.profiles.visibility.privateHint,
+  Visibility.ovWide => t.profiles.visibility.ovHint,
+  Visibility.public => t.profiles.visibility.publicHint,
   _ => t.profiles.visibility.divisionHint(division: visibilityLabel(visibility)),
 };

--- a/lib/features/profiles/utils/social_media_type_translation.dart
+++ b/lib/features/profiles/utils/social_media_type_translation.dart
@@ -1,17 +1,17 @@
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.enums.swagger.dart';
 
-String getSocialMediaTypeTranslation(SocialMediaEntryType type) {
+String getSocialMediaTypeTranslation(SocialMediaType type) {
   switch (type) {
-    case SocialMediaEntryType.facebook:
+    case SocialMediaType.facebook:
       return t.profiles.socialMediaType.facebook;
-    case SocialMediaEntryType.instagram:
+    case SocialMediaType.instagram:
       return t.profiles.socialMediaType.instagram;
-    case SocialMediaEntryType.mastodon:
+    case SocialMediaType.mastodon:
       return t.profiles.socialMediaType.mastodon;
-    case SocialMediaEntryType.twitter:
+    case SocialMediaType.twitter:
       return t.profiles.socialMediaType.twitter;
-    case SocialMediaEntryType.chatbegruenung:
+    case SocialMediaType.chatbegruenung:
       return t.profiles.socialMediaType.chatbegruenung;
     default:
       return type.value ?? '';

--- a/lib/features/profiles/widgets/profile_visibility_setting.dart
+++ b/lib/features/profiles/widgets/profile_visibility_setting.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/constants/constants.dart';
-import 'package:gruene_app/app/services/gruene_api_profile_service.dart';
 import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/app/utils/loading_overlay.dart';
@@ -9,6 +8,7 @@ import 'package:gruene_app/app/utils/profile.dart';
 import 'package:gruene_app/app/widgets/dialog_close_button.dart';
 import 'package:gruene_app/app/widgets/option_slider.dart';
 import 'package:gruene_app/app/widgets/stable_height_text.dart';
+import 'package:gruene_app/features/profiles/domain/profiles_api_service.dart';
 import 'package:gruene_app/features/profiles/utils/profile_visibility.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
@@ -39,12 +39,11 @@ class _ProfileVisibilitySettingState extends State<ProfileVisibilitySetting> {
     }
 
     final teamsService = GetIt.I<GrueneApiTeamsService>();
-    final profileService = GetIt.I<GrueneApiProfileService>();
     final newProfile = widget.profile.copyWith(privacy: widget.profile.privacy.copyWith(overall: _selectedVisibility));
 
     final team = await tryAndNotify(
       function: () async {
-        await profileService.updateProfile(newProfile);
+        await updateProfile(newProfile);
         return await teamsService.getOwnTeam();
       },
       context: context,

--- a/lib/features/profiles/widgets/profile_visibility_setting.dart
+++ b/lib/features/profiles/widgets/profile_visibility_setting.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Visibility;
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/constants/constants.dart';
 import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
@@ -24,7 +24,7 @@ class ProfileVisibilitySetting extends StatefulWidget {
 }
 
 class _ProfileVisibilitySettingState extends State<ProfileVisibilitySetting> {
-  late ProfilePrivacySettingsOverall _selectedVisibility;
+  late Visibility _selectedVisibility;
 
   @override
   void initState() {
@@ -50,7 +50,7 @@ class _ProfileVisibilitySettingState extends State<ProfileVisibilitySetting> {
       successMessage: t.profiles.visibility.updated,
     );
 
-    if (_selectedVisibility == ProfilePrivacySettingsOverall.private && team != null && mounted) {
+    if (_selectedVisibility == Visibility.private && team != null && mounted) {
       await showDialog<bool>(
         context: context,
         builder: (_) => AlertDialog(
@@ -115,7 +115,7 @@ class _ProfileVisibilitySettingState extends State<ProfileVisibilitySetting> {
                 ),
                 StableHeightText(
                   text: visibilityHint(_selectedVisibility),
-                  longestText: visibilityHint(ProfilePrivacySettingsOverall.private),
+                  longestText: visibilityHint(Visibility.private),
                   style: theme.textTheme.bodyMedium!,
                 ),
                 OptionSlider(
@@ -137,12 +137,8 @@ Future<Profile?> showProfileVisibilitySetting(
   BuildContext context,
   Profile profile, {
   bool explicitTeamHint = false,
-}) async {
-  if (profile.memberships == null) return null;
-
-  return await showModalBottomSheet<Profile>(
-    context: context,
-    useRootNavigator: true,
-    builder: (context) => ProfileVisibilitySetting(profile: profile, explicitTeamHint: explicitTeamHint),
-  );
-}
+}) async => await showModalBottomSheet<Profile>(
+  context: context,
+  useRootNavigator: true,
+  builder: (context) => ProfileVisibilitySetting(profile: profile, explicitTeamHint: explicitTeamHint),
+);

--- a/swaggers/gruene-api.yaml
+++ b/swaggers/gruene-api.yaml
@@ -379,35 +379,24 @@ paths:
             minimum: 1
             default: 20
             type: number
+        - name: hierarchy
+          required: false
+          in: query
+          description: Filter by hierarchy
+          schema:
+            $ref: '#/components/schemas/HierarchyType'
+        - name: level
+          required: false
+          in: query
+          description: Filter by hierarchy level
+          schema:
+            $ref: '#/components/schemas/HierarchyLevel'
         - name: offset
           required: false
           in: query
           schema:
             minimum: 0
             type: number
-        - name: hierarchy
-          required: false
-          in: query
-          description: Filter by hierarchy
-          schema:
-            example: GR
-            type: string
-            enum:
-              - GR
-              - GJ
-              - KPV
-        - name: level
-          required: false
-          in: query
-          description: Filter by hierarchy level
-          schema:
-            example: BV
-            type: string
-            enum:
-              - BV
-              - LV
-              - KV
-              - OV
         - name: division_key
           required: false
           in: query
@@ -724,6 +713,12 @@ paths:
             minimum: 1
             default: 20
             type: number
+        - name: type
+          required: false
+          in: query
+          description: Filter by type
+          schema:
+            $ref: '#/components/schemas/TagType'
         - name: offset
           required: false
           in: query
@@ -736,16 +731,6 @@ paths:
           description: Search label attributes for substring
           schema:
             type: string
-        - name: type
-          required: false
-          in: query
-          description: Filter by type
-          schema:
-            example: interest
-            type: string
-            enum:
-              - skill
-              - interest
       responses:
         '200':
           description: ''
@@ -1395,12 +1380,7 @@ paths:
           in: query
           description: filter by POI type
           schema:
-            example: POSTER
-            type: string
-            enum:
-              - FLYER_SPOT
-              - POSTER
-              - HOUSE
+            $ref: '#/components/schemas/PoiType'
         - name: campaignId
           required: false
           in: query
@@ -1502,12 +1482,7 @@ paths:
           in: query
           description: filter by POI type
           schema:
-            example: POSTER
-            type: string
-            enum:
-              - FLYER_SPOT
-              - POSTER
-              - HOUSE
+            $ref: '#/components/schemas/PoiType'
         - name: campaignId
           required: false
           in: query
@@ -2387,6 +2362,20 @@ paths:
             minimum: 1
             maximum: 50
             type: number
+        - name: start
+          required: false
+          in: query
+          schema:
+            format: date-time
+            example: '2026-03-20T06:03:50.427'
+            type: string
+        - name: end
+          required: false
+          in: query
+          schema:
+            format: date-time
+            example: '2026-04-23T12:15:59.123'
+            type: string
         - name: offset
           required: false
           in: query
@@ -2634,6 +2623,26 @@ paths:
             minimum: 1
             default: 20
             type: number
+        - name: assignment_status
+          required: false
+          in: query
+          description: >-
+            Filter by assignment status - is the role currently assigned to any
+            user or to none
+          schema:
+            $ref: '#/components/schemas/RoleAssignmentStatus'
+        - name: hierarchy
+          required: false
+          in: query
+          description: Filter by hierarchy type
+          schema:
+            $ref: '#/components/schemas/HierarchyType'
+        - name: level
+          required: false
+          in: query
+          description: Filter by hierarchy level
+          schema:
+            $ref: '#/components/schemas/RoleLevel'
         - name: offset
           required: false
           in: query
@@ -2662,17 +2671,6 @@ paths:
             type: array
             items:
               type: string
-        - name: assignment_status
-          required: false
-          in: query
-          description: >-
-            Filter by assignment status - is the role currently assigned to any
-            user or to none
-          schema:
-            type: string
-            enum:
-              - assigned
-              - unassigned
         - name: assignment_status_in
           required: false
           in: query
@@ -2681,29 +2679,6 @@ paths:
             type: array
             items:
               type: string
-        - name: hierarchy
-          required: false
-          in: query
-          description: Filter by hierarchy type
-          schema:
-            type: string
-            enum:
-              - GR
-              - GJ
-              - KPV
-        - name: level
-          required: false
-          in: query
-          description: Filter by hierarchy level
-          schema:
-            type: string
-            enum:
-              - ALL
-              - BV
-              - LV
-              - KV
-              - OV
-              - BEZV
       responses:
         '200':
           description: ''
@@ -3034,30 +3009,13 @@ paths:
           in: query
           description: filter by record type
           schema:
-            example: REGIONAL_CHAPTER
-            type: string
-            enum:
-              - PARTY
-              - REGIONAL_CHAPTER
-              - COMMITTEE
-              - YOUTH_ORGANIZATION
-              - SUB_ORGANIZATION
-              - PERSON
-              - PARLIAMENTARY_GROUP
+            $ref: '#/components/schemas/GreenDirectoryRecordType'
         - name: level
           required: false
           in: query
           description: filter by location level
           schema:
-            example: DE:KREISVERBAND
-            type: string
-            enum:
-              - DE:BUNDESVERBAND
-              - DE:LANDESVERBAND
-              - DE:BEZIRKSVERBAND
-              - DE:KREISVERBAND
-              - DE:REGIONALVERBAND
-              - DE:ORTSVERBAND
+            $ref: '#/components/schemas/GreenDirectoryLocationLevel'
         - name: divisionKey
           required: false
           in: query
@@ -3201,15 +3159,7 @@ paths:
           in: query
           description: filter by location level
           schema:
-            example: DE:KREISVERBAND
-            type: string
-            enum:
-              - DE:BUNDESVERBAND
-              - DE:LANDESVERBAND
-              - DE:BEZIRKSVERBAND
-              - DE:KREISVERBAND
-              - DE:REGIONALVERBAND
-              - DE:ORTSVERBAND
+            $ref: '#/components/schemas/GreenDirectoryLocationLevel'
         - name: offset
           required: false
           in: query
@@ -3604,10 +3554,10 @@ info:
   contact: {}
 tags: []
 servers:
+  - url: http://0.0.0.0:5000
+    description: localhost
   - url: https://api.gruene.de
     description: Production
-  - url: http://192.168.178.35:5000
-    description: Development
 components:
   securitySchemes:
     basic:
@@ -3821,17 +3771,20 @@ components:
           $ref: '#/components/schemas/NotificationChannelSettings'
       required:
         - inApp
+    NotificationType:
+      type: string
+      enum:
+        - campaigns.teamMembership.updated
+        - campaigns.team-top10.updated
+        - campaigns.routeAssignment.updated
+        - campaigns.areaAssignment.updated
+        - news.published
     NotificationDeliveryRule:
       type: object
       properties:
         type:
-          type: string
-          enum:
-            - campaigns.teamMembership.updated
-            - campaigns.team-top10.updated
-            - campaigns.routeAssignment.updated
-            - campaigns.areaAssignment.updated
-            - news.published
+          allOf:
+            - $ref: '#/components/schemas/NotificationType'
         inApp:
           $ref: '#/components/schemas/NotificationChannelSettings'
       required:
@@ -3882,27 +3835,35 @@ components:
       required:
         - items
         - count
+    NbExternalRefType:
+      type: string
+      enum:
+        - SHERPA
+      description: Filter by external reference type
+    NbGroupLevel:
+      type: string
+      enum:
+        - DE:BUNDESVERBAND
+        - DE:LANDESVERBAND
+        - DE:KREISVERBAND
+        - DE:ORTSVERBAND
+      description: Filter by role level
     NbGroupFilter:
       type: object
       properties:
         filter[external_refs.type]:
-          type: string
           description: Filter by external reference type
           example: SHERPA
-          enum:
-            - SHERPA
+          allOf:
+            - $ref: '#/components/schemas/NbExternalRefType'
         filter[external_refs.key]:
           type: string
           description: Filter by external reference ID (sherpa role id)
           example: '12345678'
         filter[level]:
           description: Filter by role level
-          enum:
-            - DE:BUNDESVERBAND
-            - DE:LANDESVERBAND
-            - DE:KREISVERBAND
-            - DE:ORTSVERBAND
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/NbGroupLevel'
         filter[type]:
           type: string
           description: Filter by role type
@@ -3966,6 +3927,14 @@ components:
             $ref: '#/components/schemas/NbGroup'
       required:
         - items
+    NbRegionalChapterType:
+      type: string
+      enum:
+        - BV
+        - LV
+        - KV
+        - OV
+      description: Filter by type
     NbRegionalChapterFilter:
       type: object
       properties:
@@ -3978,12 +3947,8 @@ components:
           maxLength: 8
         filter[type]:
           description: Filter by type
-          enum:
-            - BV
-            - LV
-            - KV
-            - OV
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/NbRegionalChapterType'
     NbRegionalChapter:
       type: object
       properties:
@@ -4030,6 +3995,19 @@ components:
       required:
         - count
         - items
+    HierarchyType:
+      type: string
+      enum:
+        - GR
+        - GJ
+        - KPV
+    HierarchyLevel:
+      type: string
+      enum:
+        - BV
+        - LV
+        - KV
+        - OV
     Address:
       type: object
       properties:
@@ -4229,47 +4207,53 @@ components:
         - id
         - country
         - number
+    MessengerType:
+      type: string
+      enum:
+        - threema
     MessengerEntry:
       type: object
       properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/MessengerType'
         id:
           type: string
           example: '123'
-        type:
-          type: string
-          example: threema
-          enum:
-            - threema
         externalId:
           type: string
           example: 822d7a5a
       required:
-        - id
         - type
+        - id
         - externalId
+    SocialMediaType:
+      type: string
+      enum:
+        - facebook
+        - instagram
+        - mastodon
+        - twitter
+        - chatbegruenung
+      description: Type of social media entry
     SocialMediaEntry:
       type: object
       properties:
-        id:
-          type: string
-          example: '123'
         type:
           description: Type of social media entry
           example: mastodon
-          enum:
-            - facebook
-            - instagram
-            - mastodon
-            - twitter
-            - chatbegruenung
+          allOf:
+            - $ref: '#/components/schemas/SocialMediaType'
+        id:
           type: string
+          example: '123'
         url:
           type: string
           description: Url to the platform account
           example: https://mastodon.online/@saxgruen
       required:
-        - id
         - type
+        - id
         - url
     ProfileTag:
       type: object
@@ -4405,6 +4389,7 @@ components:
         - messengers
         - socialMedia
         - tags
+        - memberships
         - roles
         - achievements
     FindProfilesResponse:
@@ -4426,39 +4411,30 @@ components:
           type: string
       required:
         - userId
+    Visibility:
+      type: string
+      enum:
+        - PRIVATE
+        - PUBLIC
+        - BV_WIDE
+        - LV_WIDE
+        - KV_WIDE
+        - OV_WIDE
     ProfilePrivacySettings:
       type: object
       properties:
         overall:
           example: BV_WIDE
-          enum:
-            - PRIVATE
-            - PUBLIC
-            - BV_WIDE
-            - LV_WIDE
-            - KV_WIDE
-            - OV_WIDE
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/Visibility'
         email:
           example: PRIVATE
-          enum:
-            - PRIVATE
-            - PUBLIC
-            - BV_WIDE
-            - LV_WIDE
-            - KV_WIDE
-            - OV_WIDE
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/Visibility'
         chatbegruenung:
           example: PUBLIC
-          enum:
-            - PRIVATE
-            - PUBLIC
-            - BV_WIDE
-            - LV_WIDE
-            - KV_WIDE
-            - OV_WIDE
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/Visibility'
       required:
         - overall
         - email
@@ -4539,6 +4515,7 @@ components:
         - messengers
         - socialMedia
         - tags
+        - memberships
         - roles
         - achievements
         - privacy
@@ -4563,10 +4540,8 @@ components:
       type: object
       properties:
         type:
-          type: string
-          example: threema
-          enum:
-            - threema
+          allOf:
+            - $ref: '#/components/schemas/MessengerType'
         externalId:
           type: string
           example: 822d7a5a
@@ -4580,15 +4555,10 @@ components:
       type: object
       properties:
         type:
-          type: string
           description: Type of social media entry
           example: mastodon
-          enum:
-            - facebook
-            - instagram
-            - mastodon
-            - twitter
-            - chatbegruenung
+          allOf:
+            - $ref: '#/components/schemas/SocialMediaType'
         url:
           type: string
           description: Url to the platform account
@@ -4634,6 +4604,11 @@ components:
         - socialMedia
         - tags
         - privacy
+    TagType:
+      type: string
+      enum:
+        - skill
+        - interest
     FindProfileTagsResponse:
       type: object
       properties:
@@ -4681,22 +4656,25 @@ components:
       required:
         - data
         - meta
+    OffboardingServiceUserStatus:
+      type: string
+      enum:
+        - deleted
+        - not_found
+        - anonymized
     UpsertOffboardingServiceUser:
       type: object
       properties:
+        status:
+          allOf:
+            - $ref: '#/components/schemas/OffboardingServiceUserStatus'
         id:
           type: string
           description: The user's id.
           example: '12345678'
-        status:
-          enum:
-            - deleted
-            - not_found
-            - anonymized
-          type: string
       required:
-        - id
         - status
+        - id
     BatchUpdateOffboardingServiceUsers:
       type: object
       properties:
@@ -4705,6 +4683,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/UpsertOffboardingServiceUser'
+    AreaType:
+      type: string
+      enum:
+        - FLYER_SPOT
+        - POSTER
+        - HOUSE
+    AreaStatus:
+      type: string
+      enum:
+        - OPEN
+        - CLOSED
     Polygon:
       type: object
       properties:
@@ -4731,17 +4720,12 @@ components:
     UpdateArea:
       type: object
       properties:
-        status:
-          enum:
-            - OPEN
-            - CLOSED
-          type: string
         type:
-          enum:
-            - FLYER_SPOT
-            - POSTER
-            - HOUSE
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/AreaType'
+        status:
+          allOf:
+            - $ref: '#/components/schemas/AreaStatus'
         comment:
           type: string
           nullable: true
@@ -4751,8 +4735,8 @@ components:
         polygon:
           $ref: '#/components/schemas/Polygon'
       required:
-        - status
         - type
+        - status
         - comment
         - name
         - polygon
@@ -4760,11 +4744,8 @@ components:
       type: object
       properties:
         type:
-          enum:
-            - FLYER_SPOT
-            - POSTER
-            - HOUSE
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/AreaType'
         campaignId:
           type: string
           nullable: true
@@ -4848,17 +4829,6 @@ components:
         - comment
         - name
         - polygon
-    AreaStatus:
-      type: string
-      enum:
-        - OPEN
-        - CLOSED
-    AreaType:
-      type: string
-      enum:
-        - FLYER_SPOT
-        - POSTER
-        - HOUSE
     FindAreasResponse:
       type: object
       properties:
@@ -4872,10 +4842,8 @@ components:
       type: object
       properties:
         status:
-          enum:
-            - OPEN
-            - CLOSED
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/AreaStatus'
       required:
         - status
     AreaAssignTeam:
@@ -4885,6 +4853,27 @@ components:
           type: string
           nullable: true
           description: If null => unassign, if string => assign.
+    CampaignScope:
+      type: string
+      enum:
+        - EU
+        - FEDERAL
+        - STATE
+        - DISTRICT
+        - MIXED
+    CampaignType:
+      type: string
+      enum:
+        - ELECTION
+        - INITIATIVE
+    CampaignStatus:
+      type: string
+      enum:
+        - DRAFT
+        - ACTIVE
+        - PAUSED
+        - CLOSED
+        - ARCHIVED
     UpdateCampaign:
       type: object
       properties:
@@ -4895,6 +4884,15 @@ components:
           type: string
           nullable: true
           format: date-time
+        scope:
+          allOf:
+            - $ref: '#/components/schemas/CampaignScope'
+        type:
+          allOf:
+            - $ref: '#/components/schemas/CampaignType'
+        status:
+          allOf:
+            - $ref: '#/components/schemas/CampaignStatus'
         end:
           type: string
           nullable: true
@@ -4904,35 +4902,14 @@ components:
           format: date-time
         name:
           type: string
-        scope:
-          enum:
-            - EU
-            - FEDERAL
-            - STATE
-            - DISTRICT
-            - MIXED
-          type: string
-        type:
-          enum:
-            - ELECTION
-            - INITIATIVE
-          type: string
-        status:
-          enum:
-            - DRAFT
-            - ACTIVE
-            - PAUSED
-            - CLOSED
-            - ARCHIVED
-          type: string
         divisionKey:
           type: string
       required:
-        - electionDate
-        - name
         - scope
         - type
         - status
+        - electionDate
+        - name
         - divisionKey
     CreateCampaign:
       type: object
@@ -4944,6 +4921,15 @@ components:
           type: string
           nullable: true
           format: date-time
+        scope:
+          allOf:
+            - $ref: '#/components/schemas/CampaignScope'
+        type:
+          allOf:
+            - $ref: '#/components/schemas/CampaignType'
+        status:
+          allOf:
+            - $ref: '#/components/schemas/CampaignStatus'
         end:
           type: string
           nullable: true
@@ -4953,35 +4939,14 @@ components:
           format: date-time
         name:
           type: string
-        scope:
-          enum:
-            - EU
-            - FEDERAL
-            - STATE
-            - DISTRICT
-            - MIXED
-          type: string
-        type:
-          enum:
-            - ELECTION
-            - INITIATIVE
-          type: string
-        status:
-          enum:
-            - DRAFT
-            - ACTIVE
-            - PAUSED
-            - CLOSED
-            - ARCHIVED
-          type: string
         divisionKey:
           type: string
       required:
-        - electionDate
-        - name
         - scope
         - type
         - status
+        - electionDate
+        - name
         - divisionKey
     Campaign:
       type: object
@@ -5175,19 +5140,23 @@ components:
         - zip
         - street
         - houseNumber
+    PosterStatus:
+      type: string
+      enum:
+        - OK
+        - DAMAGED
+        - REMOVED
+        - MISSING
+        - TO_BE_MOVED
+      description: Current status of the poster.
     PoiPoster:
       type: object
       properties:
         status:
           description: Current status of the poster.
           example: OK
-          enum:
-            - OK
-            - DAMAGED
-            - REMOVED
-            - MISSING
-            - TO_BE_MOVED
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/PosterStatus'
         comment:
           type: string
           nullable: true
@@ -5238,9 +5207,18 @@ components:
             - $ref: '#/components/schemas/PoiHouse'
       required:
         - address
+    PoiType:
+      type: string
+      enum:
+        - FLYER_SPOT
+        - POSTER
+        - HOUSE
     CreatePoi:
       type: object
       properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/PoiType'
         coords:
           description: Coordinates represented in GeoJSON [longitude, latitude]
           example:
@@ -5251,12 +5229,6 @@ components:
           type: array
           items:
             type: number
-        type:
-          enum:
-            - FLYER_SPOT
-            - POSTER
-            - HOUSE
-          type: string
         campaignId:
           type: string
           nullable: true
@@ -5275,8 +5247,8 @@ components:
           allOf:
             - $ref: '#/components/schemas/PoiHouse'
       required:
-        - coords
         - type
+        - coords
         - address
     Image:
       type: object
@@ -5415,6 +5387,17 @@ components:
         - total
         - offset
         - limit
+    RouteType:
+      type: string
+      enum:
+        - FLYER_SPOT
+        - POSTER
+        - HOUSE
+    RouteStatus:
+      type: string
+      enum:
+        - OPEN
+        - CLOSED
     LineString:
       type: object
       properties:
@@ -5443,17 +5426,12 @@ components:
     UpdateRoute:
       type: object
       properties:
-        status:
-          enum:
-            - OPEN
-            - CLOSED
-          type: string
         type:
-          enum:
-            - FLYER_SPOT
-            - POSTER
-            - HOUSE
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/RouteType'
+        status:
+          allOf:
+            - $ref: '#/components/schemas/RouteStatus'
         name:
           type: string
           nullable: true
@@ -5464,23 +5442,20 @@ components:
         lineString:
           $ref: '#/components/schemas/LineString'
       required:
-        - status
         - type
+        - status
         - name
         - description
         - lineString
     CreateRoute:
       type: object
       properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/RouteType'
         campaignId:
           type: string
           nullable: true
-        type:
-          enum:
-            - FLYER_SPOT
-            - POSTER
-            - HOUSE
-          type: string
         name:
           type: string
           nullable: true
@@ -5545,17 +5520,6 @@ components:
         - name
         - description
         - lineString
-    RouteType:
-      type: string
-      enum:
-        - FLYER_SPOT
-        - POSTER
-        - HOUSE
-    RouteStatus:
-      type: string
-      enum:
-        - OPEN
-        - CLOSED
     FindRoutesResponse:
       type: object
       properties:
@@ -5569,10 +5533,8 @@ components:
       type: object
       properties:
         status:
-          enum:
-            - OPEN
-            - CLOSED
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/RouteStatus'
       required:
         - status
     RouteAssignTeam:
@@ -5787,15 +5749,8 @@ components:
       type: object
       properties:
         status:
-          enum:
-            - OK
-            - DAMAGED
-            - REMOVED
-            - MISSING
-            - TO_BE_MOVED
-            - OPENED_DOORS
-            - CLOSED_DOORS
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/PoiStatus'
         own:
           type: number
           description: Total number of POIs created or owned by the current user.
@@ -5874,19 +5829,22 @@ components:
         - poster
         - flyer
         - house
+    TeamMembershipType:
+      type: string
+      enum:
+        - LEAD
+        - MEMBER
     CreateTeamMembership:
       type: object
       properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/TeamMembershipType'
         userId:
           type: string
-        type:
-          enum:
-            - LEAD
-            - MEMBER
-          type: string
       required:
-        - userId
         - type
+        - userId
     CreateTeam:
       type: object
       properties:
@@ -6131,25 +6089,26 @@ components:
     UpdateTeamMembership:
       type: object
       properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/TeamMembershipType'
         userId:
           type: object
-        type:
-          type: string
-          enum:
-            - LEAD
-            - MEMBER
       required:
-        - userId
         - type
+        - userId
+    TeamMembershipStatusUpdateType:
+      type: string
+      enum:
+        - ACCEPT
+        - REJECT
+        - RESIGN
     UpdateTeamMembershipStatus:
       type: object
       properties:
         type:
-          type: string
-          enum:
-            - ACCEPT
-            - REJECT
-            - RESIGN
+          allOf:
+            - $ref: '#/components/schemas/TeamMembershipStatusUpdateType'
       required:
         - type
     UpdateTeam:
@@ -6321,6 +6280,20 @@ components:
       required:
         - areas
         - routes
+    RoleAssignmentStatus:
+      type: string
+      enum:
+        - assigned
+        - unassigned
+    RoleLevel:
+      type: string
+      enum:
+        - ALL
+        - BV
+        - LV
+        - KV
+        - OV
+        - BEZV
     RoleAlias:
       type: object
       properties:
@@ -6703,33 +6676,49 @@ components:
             $ref: '#/components/schemas/Bookmark'
       required:
         - data
+    BookmarkType:
+      type: string
+      enum:
+        - NEWS
     CreateBookmark:
       type: object
       properties:
         type:
-          type: string
-          enum:
-            - NEWS
+          allOf:
+            - $ref: '#/components/schemas/BookmarkType'
         itemId:
           type: string
       required:
         - type
         - itemId
+    GreenDirectoryRecordType:
+      type: string
+      enum:
+        - PARTY
+        - REGIONAL_CHAPTER
+        - COMMITTEE
+        - YOUTH_ORGANIZATION
+        - SUB_ORGANIZATION
+        - PERSON
+        - PARLIAMENTARY_GROUP
+    GreenDirectoryRecordUrlType:
+      type: string
+      enum:
+        - WEBSITE
+        - FACEBOOK
+        - TWITTER
+        - INSTAGRAM
+        - BLUESKY
+        - MASTODON
+        - LOOPS
+        - YOUTUBE
+        - MAILINGLIST
     GreenDirectoryUrl:
       type: object
       properties:
         type:
-          type: string
-          enum:
-            - WEBSITE
-            - FACEBOOK
-            - TWITTER
-            - INSTAGRAM
-            - BLUESKY
-            - MASTODON
-            - LOOPS
-            - YOUTUBE
-            - MAILINGLIST
+          allOf:
+            - $ref: '#/components/schemas/GreenDirectoryRecordUrlType'
         url:
           type: string
           format: uri
@@ -6749,14 +6738,17 @@ components:
       required:
         - purpose
         - address
+    GreenDirectoryRecordExternalRefType:
+      type: string
+      enum:
+        - WIKIDATA
+        - WIKIPEDIA
     GreenDirectoryExternalRef:
       type: object
       properties:
         type:
-          type: string
-          enum:
-            - WIKIDATA
-            - WIKIPEDIA
+          allOf:
+            - $ref: '#/components/schemas/GreenDirectoryRecordExternalRefType'
         value:
           type: string
           minLength: 1
@@ -6779,15 +6771,8 @@ components:
       type: object
       properties:
         type:
-          type: string
-          enum:
-            - PARTY
-            - REGIONAL_CHAPTER
-            - COMMITTEE
-            - YOUTH_ORGANIZATION
-            - SUB_ORGANIZATION
-            - PERSON
-            - PARLIAMENTARY_GROUP
+          allOf:
+            - $ref: '#/components/schemas/GreenDirectoryRecordType'
         divisionKey:
           type: string
           nullable: true
@@ -6907,6 +6892,15 @@ components:
         - externalRefs
         - name
         - person
+    GreenDirectoryLocationLevel:
+      type: string
+      enum:
+        - DE:BUNDESVERBAND
+        - DE:LANDESVERBAND
+        - DE:BEZIRKSVERBAND
+        - DE:KREISVERBAND
+        - DE:REGIONALVERBAND
+        - DE:ORTSVERBAND
     FindGreenDirectoryRecordsResponse:
       type: object
       properties:
@@ -6952,6 +6946,9 @@ components:
     CreateGreenDirectoryLocation:
       type: object
       properties:
+        level:
+          allOf:
+            - $ref: '#/components/schemas/GreenDirectoryLocationLevel'
         country:
           type: string
           minLength: 2
@@ -6960,15 +6957,6 @@ components:
           type: string
           nullable: true
           minLength: 1
-        level:
-          type: string
-          enum:
-            - DE:BUNDESVERBAND
-            - DE:LANDESVERBAND
-            - DE:BEZIRKSVERBAND
-            - DE:KREISVERBAND
-            - DE:REGIONALVERBAND
-            - DE:ORTSVERBAND
         region:
           type: string
           nullable: true
@@ -6982,8 +6970,8 @@ components:
           nullable: true
           minLength: 1
       required:
-        - country
         - level
+        - country
     FindGreenDirectoryLocationsResponse:
       type: object
       properties:
@@ -6999,6 +6987,9 @@ components:
     UpdateGreenDirectoryLocation:
       type: object
       properties:
+        level:
+          allOf:
+            - $ref: '#/components/schemas/GreenDirectoryLocationLevel'
         country:
           type: string
           minLength: 2
@@ -7007,15 +6998,6 @@ components:
           type: string
           nullable: true
           minLength: 1
-        level:
-          enum:
-            - DE:BUNDESVERBAND
-            - DE:LANDESVERBAND
-            - DE:BEZIRKSVERBAND
-            - DE:KREISVERBAND
-            - DE:REGIONALVERBAND
-            - DE:ORTSVERBAND
-          type: string
         region:
           type: string
           nullable: true
@@ -7029,8 +7011,8 @@ components:
           nullable: true
           minLength: 1
       required:
-        - country
         - level
+        - country
     CalendarSelection:
       type: string
       enum:


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix the update of the profile visibility if the user has some profile tags set.
The problem was caused by just using `body: UpdateProfile.fromJson(profile.toJson())` when updating the profile.
This has been fixed by correctly implementing a mapping from a profile to update profile dto.
Furthermore, this PR updates the API definition (and the client code) to reuse shared enums.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Correctly map `Profile` to `UpdateProfile` dto when updating a profile
- Update api definition
- Fix usages of merged API enums
- Remove now redundant non-null checks for memberships

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Set a profile tag and try to update the profile visibility.
Check that the campaign features still work as expected.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1084

---