### PR TITLE
Fix membership card route name

### DIFF
--- a/lib/app/constants/route_locations.dart
+++ b/lib/app/constants/route_locations.dart
@@ -12,7 +12,7 @@ class RouteLocations {
   static const String tokenInput = 'token-input';
   static const String tokenScan = 'token-scan';
   static const String pushNotifications = 'push-notifications';
-  static const String digitalMembershipCard = 'digital-membership-card';
+  static const String membershipCard = 'membership-card';
 
   static const String campaignDoorDetail = 'door';
   static const String campaignPosterDetail = 'poster';

--- a/lib/app/constants/routes.dart
+++ b/lib/app/constants/routes.dart
@@ -95,11 +95,11 @@ class Routes {
       return null;
     },
   );
-  static GoRoute digitalMembershipCard = buildRoute(RouteLocations.digitalMembershipCard, MembershipCardScreen());
+  static GoRoute membershipCard = buildRoute(RouteLocations.membershipCard, MembershipCardScreen());
   static GoRoute profiles = buildRoute(
     RouteLocations.getRoute([RouteLocations.profiles]),
     OwnProfileScreen(),
-    routes: [digitalMembershipCard],
+    routes: [membershipCard],
   );
   static GoRoute mfaTokenInput = buildRoute(RouteLocations.tokenInput, TokenInputScreen());
   static GoRoute mfaTokenScan = buildRoute(RouteLocations.tokenScan, TokenScanScreen(), routes: [mfaTokenInput]);

--- a/lib/features/profiles/screens/own_profile_screen.dart
+++ b/lib/features/profiles/screens/own_profile_screen.dart
@@ -42,7 +42,7 @@ class OwnProfileScreen extends StatelessWidget {
                   children: [
                     TextListItem(
                       title: t.profiles.myMembershipCard,
-                      onPress: () => context.pushNested(Routes.digitalMembershipCard.path),
+                      onPress: () => context.pushNested(Routes.membershipCard.path),
                     ),
                     TextListItem(
                       title: t.profiles.visibility.visibility,


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix the name of the membership card route to be always membership card instead of digital membership card.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Rename `digitalMembershipCard` to `membershipCard`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---