### PR TITLE
990  new campaign notification

### DIFF
--- a/lib/app/utils/campaign.dart
+++ b/lib/app/utils/campaign.dart
@@ -1,6 +1,10 @@
+import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/utils/app_settings.dart';
+import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/features/campaigns/helper/app_timers.dart';
+import 'package:gruene_app/i18n/translations.g.dart';
+import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
 String? getCurrentCampaignId() {
   var appSettings = GetIt.I<AppSettings>();
@@ -15,8 +19,9 @@ String? getCurrentPoiStatisticsCampaignId() {
   return currentCampaignId;
 }
 
-void switchCampaign(String? campaignId) {
+void switchCampaign(Campaign? campaign, BuildContext context) {
   var appSettings = GetIt.I<AppSettings>();
-  appSettings.campaign.activeCampaign.recentSelectedCampaignId = campaignId;
+  appSettings.campaign.activeCampaign.recentSelectedCampaignId = campaign?.id;
+  showSnackBar(context, t.campaigns.infoToast.campaigns_changed(campaignName: campaign?.name ?? t.common.notAvailable));
   GetIt.I<ActiveCampaignNotifier>().reset();
 }

--- a/lib/features/campaigns/helper/active_campaign_settings.dart
+++ b/lib/features/campaigns/helper/active_campaign_settings.dart
@@ -16,11 +16,19 @@ class ActiveCampaignSettings extends ChangeNotifier {
   String? _recentSelectedCampaignId;
   String? get recentSelectedCampaignId => _recentSelectedCampaignId;
 
+  List<String>? _recentlySeenCampaignIds;
+  List<String>? get recentlySeenCampaignIds => _recentlySeenCampaignIds;
+
   set recentSelectedCampaignId(String? recentSelectedCampaignId) {
     _recentSelectedCampaignId = recentSelectedCampaignId;
     GetIt.I<AppSettings>().campaign.recentPoiStatisticsCampaignId = null;
     save();
     notifyListeners();
+  }
+
+  set recentlySeenCampaignIds(List<String>? recentlySeenCampaignIds) {
+    _recentlySeenCampaignIds = recentlySeenCampaignIds;
+    save();
   }
 
   ActiveCampaignSettings({String? recentSelectedCampaignId}) : _recentSelectedCampaignId = recentSelectedCampaignId;

--- a/lib/features/campaigns/helper/app_timers.dart
+++ b/lib/features/campaigns/helper/app_timers.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:gruene_app/app/auth/repository/auth_repository.dart';
+import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_campaign_service.dart';
 import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
+import 'package:gruene_app/app/utils/app_settings.dart';
 import 'package:gruene_app/app/utils/campaign.dart';
 import 'package:gruene_app/app/utils/logger.dart';
 import 'package:gruene_app/features/campaigns/helper/background_timer.dart';
@@ -27,6 +29,14 @@ class AppTimers {
     );
   }
 
+  static BackgroundTimer getCheckForNewCampaignsTimer() {
+    return BackgroundTimer(
+      onTimer: _checkForNewCampaigns,
+      runEvery: Duration(minutes: 5),
+      initialRunDelay: Duration(seconds: 15),
+    );
+  }
+
   static void _flushCacheData() async {
     var authRepo = AuthRepository();
     if (await authRepo.getAccessToken() != null) {
@@ -45,6 +55,13 @@ class AppTimers {
     var authRepo = AuthRepository();
     if (await authRepo.getAccessToken() != null) {
       GetIt.I<ActiveCampaignNotifier>().checkCurrentCampaignIsActive();
+    }
+  }
+
+  static void _checkForNewCampaigns() async {
+    var authRepo = AuthRepository();
+    if (await authRepo.getAccessToken() != null) {
+      GetIt.I<NewCampaignNotifier>().checkNewCampaignsAvailable();
     }
   }
 }
@@ -92,5 +109,30 @@ class ActiveCampaignNotifier extends ChangeNotifier {
 
   void reset() {
     _isCurrentCampaignActive = true;
+  }
+}
+
+class NewCampaignNotifier extends ChangeNotifier {
+  bool _newCampaignsAvailable = false;
+  bool get newCampaignsAvailable => _newCampaignsAvailable;
+
+  void checkNewCampaignsAvailable() async {
+    try {
+      var allCampaigns = (await GetIt.I<GrueneApiCampaignService>().findCampaigns()).activeCampaigns();
+      var recentlySeenCampaignIds = GetIt.I<AppSettings>().campaign.activeCampaign.recentlySeenCampaignIds ?? [];
+
+      var newCampaigns = allCampaigns.where((c) => !recentlySeenCampaignIds.contains(c.id)).toList();
+      var valueChanged = newCampaignsAvailable != newCampaigns.isNotEmpty;
+
+      _newCampaignsAvailable = newCampaigns.isNotEmpty;
+      if (valueChanged) notifyListeners();
+    } on ClientException {
+      // Don't crash the app on network errors
+    }
+  }
+
+  void reset() {
+    _newCampaignsAvailable = false;
+    notifyListeners();
   }
 }

--- a/lib/features/campaigns/screens/campaign_select_button.dart
+++ b/lib/features/campaigns/screens/campaign_select_button.dart
@@ -12,10 +12,17 @@ class CampaignSelectButton extends StatefulWidget {
 
 class _CampaignSelectButtonState extends State<CampaignSelectButton> {
   final _newCampaignNotifier = GetIt.I<NewCampaignNotifier>();
+
   @override
   void initState() {
     super.initState();
     _newCampaignNotifier.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _newCampaignNotifier.removeListener(() => setState(() {}));
+    super.dispose();
   }
 
   @override

--- a/lib/features/campaigns/screens/campaign_select_button.dart
+++ b/lib/features/campaigns/screens/campaign_select_button.dart
@@ -1,13 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:gruene_app/features/campaigns/helper/app_timers.dart';
 import 'package:gruene_app/features/campaigns/screens/campaign_select_widget.dart';
 
-class CampaignSelectButton extends StatelessWidget {
+class CampaignSelectButton extends StatefulWidget {
   const CampaignSelectButton({super.key});
 
   @override
+  State<CampaignSelectButton> createState() => _CampaignSelectButtonState();
+}
+
+class _CampaignSelectButtonState extends State<CampaignSelectButton> {
+  final _newCampaignNotifier = GetIt.I<NewCampaignNotifier>();
+  @override
+  void initState() {
+    super.initState();
+    _newCampaignNotifier.addListener(() => setState(() {}));
+  }
+
+  @override
   Widget build(BuildContext context) {
+    var icon = const Icon(Icons.how_to_vote_outlined);
     return IconButton(
-      icon: const Icon(Icons.how_to_vote_outlined),
+      icon: _newCampaignNotifier.newCampaignsAvailable ? Badge(child: icon) : icon,
       onPressed: () => _showCampaignSelectDialog(context),
     );
   }

--- a/lib/features/campaigns/screens/campaign_select_widget.dart
+++ b/lib/features/campaigns/screens/campaign_select_widget.dart
@@ -7,18 +7,21 @@ import 'package:gruene_app/app/services/converters.dart';
 import 'package:gruene_app/app/services/gruene_api_campaign_service.dart';
 import 'package:gruene_app/app/services/gruene_api_divisions_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/app/utils/app_settings.dart';
 import 'package:gruene_app/app/utils/campaign.dart';
 import 'package:gruene_app/app/utils/utils.dart';
 import 'package:gruene_app/app/widgets/dialog_close_button.dart';
+import 'package:gruene_app/features/campaigns/helper/app_timers.dart';
 import 'package:gruene_app/features/campaigns/helper/enums.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
 
 class CampaignSelectWidget extends StatefulWidget {
   final CampaignSelectMode mode;
+  final bool storeRecentSeenCampaigns;
   static int showCounter = 0;
 
-  const CampaignSelectWidget({super.key, this.mode = CampaignSelectMode.normal});
+  const CampaignSelectWidget({super.key, this.mode = CampaignSelectMode.normal, this.storeRecentSeenCampaigns = false});
 
   @override
   State<CampaignSelectWidget> createState() => _CampaignSelectWidgetState();
@@ -30,6 +33,7 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
   List<Campaign> _activeCampaigns = [];
   List<Division> _activeCampaignDivisions = [];
   String _previousCampaignName = t.common.unknown;
+  List<String> _previouslySeenCampaignIds = [];
 
   @override
   void initState() {
@@ -70,12 +74,23 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
         ? allCampaigns.firstWhereOrNull((c) => c.id == selectedCampaignId)?.name ?? t.common.unknown
         : t.common.unknown;
 
+    var recentCampaigns = selectableCampaigns.map((c) => c.id).toList();
+    var previouslySeenCampaignIds = recentCampaigns;
+    if (widget.storeRecentSeenCampaigns) {
+      var appSettings = GetIt.I<AppSettings>();
+      previouslySeenCampaignIds = appSettings.campaign.activeCampaign.recentlySeenCampaignIds ?? [];
+
+      appSettings.campaign.activeCampaign.recentlySeenCampaignIds = recentCampaigns;
+      GetIt.I<NewCampaignNotifier>().reset();
+    }
+
     setState(() {
       _loading = false;
       _activeCampaigns = selectableCampaigns;
       _activeCampaignDivisions = activeCampaignDivisions;
       _selectedCampaignId = selectedCampaignId;
       _previousCampaignName = previousCampaignName;
+      _previouslySeenCampaignIds = previouslySeenCampaignIds;
     });
   }
 
@@ -162,6 +177,12 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
           '${_activeCampaignDivisions.firstWhere((d) => d.divisionKey == campaign.divisionKey).shortName}, ${t.campaigns.select.electionDate}: ${campaign.electionDate.getAsLocalDateString()}';
     }
 
+    Widget asBadge(bool doBadge, Widget child) => doBadge
+        ? Badge(
+            child: Container(padding: EdgeInsets.only(right: 8), child: child),
+          )
+        : child;
+
     return Container(
       decoration: BoxDecoration(
         border: Border(bottom: BorderSide(width: 0.5, color: ThemeColors.textLight)),
@@ -189,7 +210,10 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(campaignName, style: theme.textTheme.labelLarge),
+                asBadge(
+                  !_previouslySeenCampaignIds.contains(campaignId),
+                  Text(campaignName, style: theme.textTheme.labelLarge),
+                ),
                 Text(campaignSubtitle, style: theme.textTheme.labelSmall?.apply(color: ThemeColors.textDisabled)),
               ],
             ),
@@ -215,7 +239,10 @@ Future<void> showCampaignSelectDialog(BuildContext context, {bool enforceSelect 
       context: context,
       builder: (context) => Padding(
         padding: EdgeInsets.only(bottom: max(MediaQuery.of(context).viewInsets.bottom, DesignConstants.bottomPadding)),
-        child: CampaignSelectWidget(mode: enforceSelect ? CampaignSelectMode.enforceSelect : CampaignSelectMode.normal),
+        child: CampaignSelectWidget(
+          mode: enforceSelect ? CampaignSelectMode.enforceSelect : CampaignSelectMode.normal,
+          storeRecentSeenCampaigns: true,
+        ),
       ),
       isScrollControlled: true,
       isDismissible: isDismissible,

--- a/lib/features/campaigns/screens/campaign_select_widget.dart
+++ b/lib/features/campaigns/screens/campaign_select_widget.dart
@@ -146,7 +146,8 @@ class _CampaignSelectWidgetState extends State<CampaignSelectWidget> {
       // Don't allow closing without selection if selection is enforced
       return;
     }
-    Navigator.of(context).pop(CampaignSelectResult.success(_selectedCampaignId));
+    var selectedCampaign = _activeCampaigns.firstWhere((c) => c.id == _selectedCampaignId);
+    Navigator.of(context).pop(CampaignSelectResult.success(selectedCampaign));
   }
 
   Widget _getCampaignRadioTile(Campaign? campaign, ThemeData theme) {
@@ -222,13 +223,14 @@ Future<void> showCampaignSelectDialog(BuildContext context, {bool enforceSelect 
       backgroundColor: theme.colorScheme.surface,
     );
     if (enforceSelect &&
-        (selectCampaignResult == null || !selectCampaignResult.success || selectCampaignResult.campaignId == null)) {
+        (selectCampaignResult == null || !selectCampaignResult.success || selectCampaignResult.campaign == null)) {
       // If selection is enforced, we need to show the dialog again if the user dismissed it without selecting
       continue;
     }
     if (selectCampaignResult != null && selectCampaignResult.success) {
       // apply selection
-      switchCampaign(selectCampaignResult.campaignId);
+      if (!context.mounted) return;
+      switchCampaign(selectCampaignResult.campaign, context);
     }
     break;
   }
@@ -248,19 +250,19 @@ Future<String?> showCampaignSelectDialogForStatistics(BuildContext context) asyn
     backgroundColor: theme.colorScheme.surface,
   );
   if (selectCampaignResult != null && selectCampaignResult.success) {
-    return selectCampaignResult.campaignId;
+    return selectCampaignResult.campaign?.id;
   }
   return null;
 }
 
 class CampaignSelectResult {
-  final String? campaignId;
+  final Campaign? campaign;
   final bool success;
 
-  CampaignSelectResult(this.success, this.campaignId);
+  CampaignSelectResult(this.success, this.campaign);
 
-  factory CampaignSelectResult.success(String? campaignId) {
-    return CampaignSelectResult(true, campaignId);
+  factory CampaignSelectResult.success(Campaign? campaign) {
+    return CampaignSelectResult(true, campaign);
   }
 
   factory CampaignSelectResult.fail() {

--- a/lib/features/campaigns/screens/teams/team_assigned_elements.dart
+++ b/lib/features/campaigns/screens/teams/team_assigned_elements.dart
@@ -211,8 +211,9 @@ class _TeamAssignedElementsState extends State<TeamAssignedElements> {
       var currentCampaign = _activeCampaigns.singleWhere((c) => c.id == currentSelectedCampaign);
       var targetCampaign = _activeCampaigns.singleWhere((c) => c.id == assignedElement.campaignId);
       if (await _confirmCampaignSwitch(currentCampaign, targetCampaign)) {
-        if (!context.mounted) return;
-        switchCampaign(targetCampaign, context);
+        var currentContext = context;
+        if (!currentContext.mounted) return;
+        switchCampaign(targetCampaign, currentContext);
       } else {
         return;
       }

--- a/lib/features/campaigns/screens/teams/team_assigned_elements.dart
+++ b/lib/features/campaigns/screens/teams/team_assigned_elements.dart
@@ -211,7 +211,8 @@ class _TeamAssignedElementsState extends State<TeamAssignedElements> {
       var currentCampaign = _activeCampaigns.singleWhere((c) => c.id == currentSelectedCampaign);
       var targetCampaign = _activeCampaigns.singleWhere((c) => c.id == assignedElement.campaignId);
       if (await _confirmCampaignSwitch(currentCampaign, targetCampaign)) {
-        switchCampaign(targetCampaign.id);
+        if (!context.mounted) return;
+        switchCampaign(targetCampaign, context);
       } else {
         return;
       }

--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -126,6 +126,7 @@
       "routes_deactivated": "Routen deaktiviert",
       "routes_aboutTitle": "Über Routen",
       "routes_aboutText": "Routen zeigen Dir, welche Wege Du am besten ablaufen kannst, um Haustüren zu besuchen, Plakate aufzuhängen oder Flyer zu verteilen. Die Routen werden von Wahlkampfkoordinator*innen im Grünen Atlas erstellt. Für mehr Informationen wende Dich bitte an Deinen Orts- oder Kreisverband.",
+      "campaigns_changed": "Kampagne geändert: ${campaignName}",
       "more": "mehr Info"
     },
     "pollingStation": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,6 +96,7 @@ Future<void> main() async {
   GetIt.I.registerSingleton<CampaignActionCache>(CampaignActionCache());
   GetIt.I.registerSingleton<OpenInvitationCampaignValueStore>(OpenInvitationCampaignValueStore());
   GetIt.I.registerSingleton<ActiveCampaignNotifier>(ActiveCampaignNotifier());
+  GetIt.I.registerSingleton<NewCampaignNotifier>(NewCampaignNotifier());
   GetIt.I.registerSingleton<BackgroundTimer>(
     AppTimers.getCampaignActionCacheTimer(),
     instanceName: 'campaignActionCacheTimer',
@@ -104,6 +105,10 @@ Future<void> main() async {
   GetIt.I.registerSingleton<BackgroundTimer>(
     AppTimers.getEnforceActiveCampaignTimer(),
     instanceName: 'enforceActiveCampaignTimer',
+  );
+  GetIt.I.registerSingleton<BackgroundTimer>(
+    AppTimers.getCheckForNewCampaignsTimer(),
+    instanceName: 'checkForNewCampaignsTimer',
   );
   GetIt.I.registerSingleton<FileManager>(FileManager());
   GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.poster.toString());


### PR DESCRIPTION
### Short Description

- check every 5mins for new campaigns
- if new campaigns appear show red dot at campaign switcher
- reset "recently seen campaigns" when campaign list is opened (only for campaign switching not stat view)

<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #990

---