### PR TITLE
Fix profile image success message

### DIFF
--- a/lib/app/screens/error_screen.dart
+++ b/lib/app/screens/error_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:gruene_app/app/theme/theme.dart';
-import 'package:gruene_app/app/utils/error_message.dart';
+import 'package:gruene_app/app/utils/error.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 
 class ErrorScreen<T> extends StatelessWidget {

--- a/lib/app/utils/error.dart
+++ b/lib/app/utils/error.dart
@@ -1,4 +1,5 @@
 import 'package:gruene_app/i18n/translations.g.dart';
+import 'package:http/http.dart';
 import 'package:keycloak_authenticator/api.dart';
 
 String getErrorMessage(Object error, {String? defaultMessage}) {
@@ -9,7 +10,7 @@ String getErrorMessage(Object error, {String? defaultMessage}) {
     };
   }
 
-  if (error.toString().contains('Failed host lookup')) {
+  if (error is ClientException || error.toString().contains('Failed host lookup')) {
     return t.error.offlineError;
   }
   return defaultMessage ?? t.error.unknownError;

--- a/lib/app/utils/loading_overlay.dart
+++ b/lib/app/utils/loading_overlay.dart
@@ -25,16 +25,16 @@ void hideLoadingOverlay() {
 Future<T?> tryAndNotify<T>({
   required Future<T> Function() function,
   required BuildContext context,
-  String? successMessage,
   String? errorMessage,
+  void Function(BuildContext rootContext, T value)? onSuccess,
   void Function(bool loading)? setLoading,
 }) async {
   final rootContext = Navigator.of(context, rootNavigator: true).context;
   setLoading != null ? setLoading(true) : showLoadingOverlay(context);
   try {
     final value = await function();
-    if (successMessage != null && rootContext.mounted) {
-      showSnackBar(rootContext, successMessage);
+    if (onSuccess != null && rootContext.mounted) {
+      onSuccess(rootContext, value);
     }
     return value;
   } catch (error) {

--- a/lib/app/utils/loading_overlay.dart
+++ b/lib/app/utils/loading_overlay.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/app/utils/error.dart';
 import 'package:gruene_app/app/utils/show_snack_bar.dart';
-import 'package:gruene_app/i18n/translations.g.dart';
-import 'package:http/http.dart';
 
 OverlayEntry? _overlay;
 
@@ -40,10 +39,7 @@ Future<T?> tryAndNotify<T>({
     return value;
   } catch (error) {
     if (rootContext.mounted) {
-      showSnackBar(
-        rootContext,
-        errorMessage ?? (error is ClientException ? t.error.offlineError : t.error.unknownError),
-      );
+      showSnackBar(rootContext, getErrorMessage(error, defaultMessage: errorMessage));
     }
   } finally {
     setLoading != null ? setLoading(false) : hideLoadingOverlay();

--- a/lib/features/events/screens/event_detail_screen.dart
+++ b/lib/features/events/screens/event_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gruene_app/app/constants/constants.dart';
 import 'package:gruene_app/app/utils/loading_overlay.dart';
+import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/app/utils/utils.dart';
 import 'package:gruene_app/app/widgets/app_bar.dart';
 import 'package:gruene_app/app/widgets/expanding_scroll_view.dart';
@@ -122,7 +123,7 @@ class EventDeletionConfirmationDialog extends StatelessWidget {
               await deleteEvent(event);
             },
             context: context,
-            successMessage: t.events.deleted,
+            onSuccess: (context, _) => showSnackBar(context, t.events.deleted),
           ),
         ),
       ],

--- a/lib/features/events/widgets/event_detail.dart
+++ b/lib/features/events/widgets/event_detail.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gruene_app/app/utils/date.dart';
 import 'package:gruene_app/app/utils/loading_overlay.dart';
+import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/app/utils/utils.dart';
 import 'package:gruene_app/app/widgets/page_info.dart';
 import 'package:gruene_app/features/events/bloc/events_bloc.dart';
@@ -92,7 +93,7 @@ class EventDetail extends StatelessWidget {
                   }
                 },
                 context: context,
-                successMessage: t.common.saved,
+                onSuccess: (context, _) => showSnackBar(context, t.common.saved),
               ),
             ),
           ],

--- a/lib/features/events/widgets/event_edit_dialog.dart
+++ b/lib/features/events/widgets/event_edit_dialog.dart
@@ -8,6 +8,7 @@ import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:gruene_app/app/utils/date.dart';
 import 'package:gruene_app/app/utils/image.dart';
 import 'package:gruene_app/app/utils/loading_overlay.dart';
+import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/app/widgets/form_section.dart';
 import 'package:gruene_app/app/widgets/full_screen_dialog.dart';
 import 'package:gruene_app/app/widgets/selection_view.dart';
@@ -319,7 +320,7 @@ Future<CalendarEvent?> save({
       return event;
     },
     context: context,
-    successMessage: t.events.updated,
+    onSuccess: (context, _) => showSnackBar(context, t.events.updated),
   );
 }
 

--- a/lib/features/mfa/screens/mfa_screen.dart
+++ b/lib/features/mfa/screens/mfa_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gruene_app/app/utils/error_message.dart';
+import 'package:gruene_app/app/utils/error.dart';
 import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/app/widgets/app_bar.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_bloc.dart';

--- a/lib/features/mfa/util/setup_mfa.dart
+++ b/lib/features/mfa/util/setup_mfa.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/constants/config.dart';
 import 'package:gruene_app/app/constants/routes.dart';
-import 'package:gruene_app/app/utils/error_message.dart';
+import 'package:gruene_app/app/utils/error.dart';
 import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_bloc.dart';
 import 'package:gruene_app/features/mfa/bloc/mfa_event.dart';

--- a/lib/features/profiles/widgets/profile_image_edit_button.dart
+++ b/lib/features/profiles/widgets/profile_image_edit_button.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:gruene_app/app/utils/image.dart';
 import 'package:gruene_app/app/utils/loading_overlay.dart';
+import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/features/profiles/domain/profiles_api_service.dart';
 import 'package:gruene_app/i18n/translations.g.dart';
 import 'package:gruene_app/swagger_generated_code/gruene_api.swagger.dart';
+import 'package:http/http.dart';
 import 'package:image_cropper/image_cropper.dart';
 
 class ProfileImageEditButton extends StatelessWidget {
@@ -13,12 +15,13 @@ class ProfileImageEditButton extends StatelessWidget {
 
   const ProfileImageEditButton({super.key, required this.profile, required this.update, required this.setLoading});
 
-  Future<void> _editProfileImage(BuildContext context) async {
+  Future<MultipartFile?> _editProfileImage(BuildContext context) async {
     final imageFile = await pickImage(context, CropAspectRatio(ratioX: 1, ratioY: 1));
-    if (imageFile == null) return;
+    if (imageFile == null) return null;
     final image = await multipartImage(imageFile, 'profileImage');
     final newProfile = await updateProfileImage(profileId: profile.id, profileImage: image);
     update(newProfile);
+    return image;
   }
 
   @override
@@ -28,7 +31,7 @@ class ProfileImageEditButton extends StatelessWidget {
       onPressed: () => tryAndNotify(
         function: () async => _editProfileImage(context),
         context: context,
-        successMessage: t.profiles.profileImage.updated,
+        onSuccess: (context, image) => image != null ? showSnackBar(context, t.profiles.profileImage.updated) : null,
         setLoading: setLoading,
       ),
       style: TextButton.styleFrom(

--- a/lib/features/profiles/widgets/profile_visibility_setting.dart
+++ b/lib/features/profiles/widgets/profile_visibility_setting.dart
@@ -5,6 +5,7 @@ import 'package:gruene_app/app/services/gruene_api_teams_service.dart';
 import 'package:gruene_app/app/theme/theme.dart';
 import 'package:gruene_app/app/utils/loading_overlay.dart';
 import 'package:gruene_app/app/utils/profiles.dart';
+import 'package:gruene_app/app/utils/show_snack_bar.dart';
 import 'package:gruene_app/app/widgets/dialog_close_button.dart';
 import 'package:gruene_app/app/widgets/option_slider.dart';
 import 'package:gruene_app/app/widgets/stable_height_text.dart';
@@ -47,7 +48,7 @@ class _ProfileVisibilitySettingState extends State<ProfileVisibilitySetting> {
         return await teamsService.getOwnTeam();
       },
       context: context,
-      successMessage: t.profiles.visibility.updated,
+      onSuccess: (context, _) => showSnackBar(context, t.profiles.visibility.updated),
     );
 
     if (_selectedVisibility == Visibility.private && team != null && mounted) {


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
So far, the success message `Profilbild gespeichert` was even shown if the user aborted the process without picking a new profile image. This PR fixes this and only shows the success message if a new profile image was actually uploaded.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Only show success message if profile image was actually updated
- Improve error messages
- Rename `error_message` to `error`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to Mitglieder > Profilbild bearbeiten > Dismiss the image picker > No success message is displayed

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---