### PR TITLE
Improve dropdown selections

### DIFF
--- a/lib/app/widgets/selection.dart
+++ b/lib/app/widgets/selection.dart
@@ -56,6 +56,7 @@ class Selection<T> extends StatelessWidget {
         containerBuilder: containerBuilder,
         emptyBuilder: emptyBuilder,
       ),
+      suffixProps: DropdownSuffixProps(clearButtonProps: ClearButtonProps(isVisible: true)),
       decoratorProps: decoratorProps,
     );
   }

--- a/lib/app/widgets/selection.dart
+++ b/lib/app/widgets/selection.dart
@@ -34,13 +34,10 @@ class Selection<T> extends StatelessWidget {
     final decoratorProps = DropDownDecoratorProps(decoration: InputDecoration(hintText: t.common.actions.select));
     final theme = Theme.of(context);
 
-    final selectedValue = selected;
-    final sortedItems = selectedValue == null
+    final selected = this.selected;
+    final sortedItems = selected == null
         ? items
-        : [
-            ...items.where((item) => compare(item, selectedValue)),
-            ...items.where((item) => !compare(item, selectedValue)),
-          ];
+        : [...items.where((item) => compare(item, selected)), ...items.where((item) => !compare(item, selected))];
 
     return DropdownSearch<T>(
       selectedItem: selected,
@@ -55,6 +52,12 @@ class Selection<T> extends StatelessWidget {
         searchFieldProps: searchFieldProps,
         containerBuilder: containerBuilder,
         emptyBuilder: emptyBuilder,
+        itemBuilder: (context, item, _, isSelected) => ListTile(
+          title: Text(itemAsString(item)),
+          trailing: selected != null && compare(item, selected)
+              ? Icon(Icons.check, color: theme.colorScheme.primary)
+              : null,
+        ),
       ),
       suffixProps: DropdownSuffixProps(clearButtonProps: ClearButtonProps(isVisible: true)),
       decoratorProps: decoratorProps,

--- a/lib/app/widgets/selection.dart
+++ b/lib/app/widgets/selection.dart
@@ -34,10 +34,18 @@ class Selection<T> extends StatelessWidget {
     final decoratorProps = DropDownDecoratorProps(decoration: InputDecoration(hintText: t.common.actions.select));
     final theme = Theme.of(context);
 
+    final selectedValue = selected;
+    final sortedItems = selectedValue == null
+        ? items
+        : [
+            ...items.where((item) => compare(item, selectedValue)),
+            ...items.where((item) => !compare(item, selectedValue)),
+          ];
+
     return DropdownSearch<T>(
       selectedItem: selected,
       onSelected: setSelected,
-      items: (query, _) => items,
+      items: (query, _) => sortedItems,
       compareFn: compare,
       filterFn: filter,
       itemAsString: itemAsString,
@@ -98,10 +106,17 @@ class MultiSelection<T> extends StatelessWidget {
       ),
     );
 
+    final sortedItems = selected.isEmpty
+        ? items
+        : [
+            ...items.where((item) => selected.any((selectedItem) => compare(item, selectedItem))),
+            ...items.where((item) => !selected.any((selectedItem) => compare(item, selectedItem))),
+          ];
+
     return DropdownSearch<T>.multiSelection(
       selectedItems: selected,
       onSelected: setSelected,
-      items: (query, _) => items,
+      items: (query, _) => sortedItems,
       compareFn: compare,
       filterFn: filter,
       itemAsString: itemAsString,


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Improve dropdown selection by sorting selected options first and adding a deselect button for single selection.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Sort selected items first while keeping the normal sorting otherwise
- Add a deselect button for single selection (i.e. division filter of profile search)
- Add checkmark to selected item in single selection

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to Mitglieder > Mitgliedersuche > Filter.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---