### PR TITLE
Fix access token refresh race condition

### DIFF
--- a/lib/app/auth/bloc/auth_bloc.dart
+++ b/lib/app/auth/bloc/auth_bloc.dart
@@ -63,9 +63,9 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       if (isValid) {
         emit(Authenticated());
       } else {
-        final refreshed = await authRepository.refreshToken();
+        final newAccessToken = await authRepository.refreshAccessToken();
         await _pushNotificationService.updateSubscriptions();
-        if (refreshed) {
+        if (newAccessToken != null) {
           emit(Authenticated());
         } else {
           emit(Unauthenticated());

--- a/lib/app/auth/repository/auth_repository.dart
+++ b/lib/app/auth/repository/auth_repository.dart
@@ -14,6 +14,8 @@ import 'package:keycloak_authenticator/api.dart';
 import 'package:uuid/uuid.dart';
 
 class AuthRepository {
+  static Completer<bool>? _refreshCompleter;
+
   final FlutterAppAuth _appAuth = FlutterAppAuth();
   final _secureStorage = GetIt.instance<FlutterSecureStorage>();
   final AuthenticatorService _authenticatorService = GetIt.I<AuthenticatorService>();
@@ -109,6 +111,26 @@ class AuthRepository {
   }
 
   Future<bool> refreshToken() async {
+    final existing = _refreshCompleter;
+    if (existing != null && !existing.isCompleted) {
+      logger.d('Token refresh already in progress, awaiting existing attempt');
+      return existing.future;
+    }
+
+    final completer = Completer<bool>();
+    _refreshCompleter = completer;
+
+    try {
+      final result = await _doRefreshToken();
+      completer.complete(result);
+      return result;
+    } catch (e, stackTrace) {
+      completer.completeError(e, stackTrace);
+      rethrow;
+    }
+  }
+
+  Future<bool> _doRefreshToken() async {
     final refreshToken = await getRefreshToken();
     if (refreshToken == null) {
       logger.d('No refresh token found');

--- a/lib/app/auth/repository/auth_repository.dart
+++ b/lib/app/auth/repository/auth_repository.dart
@@ -119,6 +119,9 @@ class AuthRepository {
 
     final completer = Completer<String?>();
     _refreshCompleter = completer;
+    // Ensure the future always has a listener so a completeError in the single-caller
+    // case is not surfaced as an unhandled async error.
+    completer.future.ignore();
 
     try {
       final result = await _refreshAccessToken();
@@ -127,6 +130,8 @@ class AuthRepository {
     } catch (e, stackTrace) {
       completer.completeError(e, stackTrace);
       rethrow;
+    } finally {
+      _refreshCompleter = null;
     }
   }
 
@@ -138,15 +143,17 @@ class AuthRepository {
     }
 
     try {
-      final TokenResponse result = await _appAuth.token(
-        TokenRequest(
-          Config.oidcClientId,
-          Config.oidcCallbackPath,
-          allowInsecureConnections: Config.isDevelopment,
-          refreshToken: refreshToken,
-          issuer: Config.oidcIssuer,
-        ),
-      );
+      final TokenResponse result = await _appAuth
+          .token(
+            TokenRequest(
+              Config.oidcClientId,
+              Config.oidcCallbackPath,
+              allowInsecureConnections: Config.isDevelopment,
+              refreshToken: refreshToken,
+              issuer: Config.oidcIssuer,
+            ),
+          )
+          .timeout(const Duration(seconds: 30));
 
       await _secureStorage.write(key: SecureStorageKeys.accessToken, value: result.accessToken);
       await _secureStorage.write(key: SecureStorageKeys.idToken, value: result.idToken);
@@ -155,8 +162,10 @@ class AuthRepository {
       return result.accessToken;
     } catch (e) {
       logger.w('Token refresh failed: $e');
-      if (e is PlatformException && (e.message?.contains('Unable to resolve host') ?? false)) {
-        // Continue with the existing access token if the app is offline
+      final isOffline =
+          (e is PlatformException && (e.message?.contains('Unable to resolve host') ?? false)) || e is TimeoutException;
+      if (isOffline) {
+        // Continue with the existing access token if the app is offline or the refresh timed out
         return getAccessToken();
       }
     }

--- a/lib/app/auth/repository/auth_repository.dart
+++ b/lib/app/auth/repository/auth_repository.dart
@@ -14,7 +14,7 @@ import 'package:keycloak_authenticator/api.dart';
 import 'package:uuid/uuid.dart';
 
 class AuthRepository {
-  static Completer<bool>? _refreshCompleter;
+  static Completer<String?>? _refreshCompleter;
 
   final FlutterAppAuth _appAuth = FlutterAppAuth();
   final _secureStorage = GetIt.instance<FlutterSecureStorage>();
@@ -110,18 +110,18 @@ class AuthRepository {
     return !isExpired;
   }
 
-  Future<bool> refreshToken() async {
+  Future<String?> refreshAccessToken() async {
     final existing = _refreshCompleter;
     if (existing != null && !existing.isCompleted) {
       logger.d('Token refresh already in progress, awaiting existing attempt');
       return existing.future;
     }
 
-    final completer = Completer<bool>();
+    final completer = Completer<String?>();
     _refreshCompleter = completer;
 
     try {
-      final result = await _doRefreshToken();
+      final result = await _refreshAccessToken();
       completer.complete(result);
       return result;
     } catch (e, stackTrace) {
@@ -130,11 +130,11 @@ class AuthRepository {
     }
   }
 
-  Future<bool> _doRefreshToken() async {
+  Future<String?> _refreshAccessToken() async {
     final refreshToken = await getRefreshToken();
     if (refreshToken == null) {
       logger.d('No refresh token found');
-      return false;
+      return null;
     }
 
     try {
@@ -152,15 +152,15 @@ class AuthRepository {
       await _secureStorage.write(key: SecureStorageKeys.idToken, value: result.idToken);
       await _secureStorage.write(key: SecureStorageKeys.refreshToken, value: result.refreshToken);
       logger.d('Token refresh successful');
-      return true;
+      return result.accessToken;
     } catch (e) {
       logger.w('Token refresh failed: $e');
       if (e is PlatformException && (e.message?.contains('Unable to resolve host') ?? false)) {
-        // Continue without successful token refresh if the app is offline
-        return true;
+        // Continue with the existing access token if the app is offline
+        return getAccessToken();
       }
     }
-    return false;
+    return null;
   }
 
   Future<void> _deleteTokens() async {

--- a/lib/app/services/access_token_authenticator.dart
+++ b/lib/app/services/access_token_authenticator.dart
@@ -27,16 +27,21 @@ class AccessTokenAuthenticator implements Authenticator {
         return null;
       }
 
-      final newAccessToken = await _authRepository.refreshAccessToken();
-      if (newAccessToken == null) {
-        logger.w('Failed to refresh access token');
+      try {
+        final newAccessToken = await _authRepository.refreshAccessToken();
+        if (newAccessToken == null) {
+          logger.w('Failed to refresh access token');
+          return null;
+        }
+
+        return applyHeaders(request, {
+          HttpHeaders.authorizationHeader: '$bearerPrefix $newAccessToken',
+          retryCountHeader: '1',
+        });
+      } catch (e) {
+        logger.w('Failed to refresh access token: $e');
         return null;
       }
-
-      return applyHeaders(request, {
-        HttpHeaders.authorizationHeader: '$bearerPrefix $newAccessToken',
-        retryCountHeader: '1',
-      });
     }
 
     return null;

--- a/lib/app/services/access_token_authenticator.dart
+++ b/lib/app/services/access_token_authenticator.dart
@@ -10,7 +10,6 @@ const retryCountHeader = 'Retry-Count';
 
 class AccessTokenAuthenticator implements Authenticator {
   final AuthRepository _authRepository = AuthRepository();
-  Completer<String?>? _completer;
 
   AccessTokenAuthenticator();
 
@@ -45,30 +44,11 @@ class AccessTokenAuthenticator implements Authenticator {
     return null;
   }
 
-  Future<String?> _refreshToken() {
-    var completer = _completer;
-    if (completer != null && !completer.isCompleted) {
-      logger.d('Access token refresh is already in progress');
-      return completer.future;
+  Future<String?> _refreshToken() async {
+    if (!await _authRepository.refreshToken()) {
+      throw Exception('Failed to refresh token');
     }
-
-    completer = Completer<String?>();
-    _completer = completer;
-
-    _authRepository
-        .refreshToken()
-        .then((success) {
-          if (success) {
-            completer?.complete(_authRepository.getAccessToken());
-          } else {
-            completer?.completeError('Failed to refresh token', StackTrace.current);
-          }
-        })
-        .onError((error, stackTrace) {
-          completer?.completeError(error ?? 'Refresh token error', stackTrace);
-        });
-
-    return completer.future;
+    return _authRepository.getAccessToken();
   }
 
   @override

--- a/lib/app/services/access_token_authenticator.dart
+++ b/lib/app/services/access_token_authenticator.dart
@@ -27,28 +27,19 @@ class AccessTokenAuthenticator implements Authenticator {
         return null;
       }
 
-      try {
-        final newAccessToken = await _refreshToken();
-        final updatedRequest = applyHeaders(request, {
-          HttpHeaders.authorizationHeader: '$bearerPrefix ${newAccessToken!}',
-          retryCountHeader: '1',
-        });
-
-        return updatedRequest;
-      } catch (e) {
-        logger.w('Failed to refresh access token: $e');
+      final newAccessToken = await _authRepository.refreshAccessToken();
+      if (newAccessToken == null) {
+        logger.w('Failed to refresh access token');
         return null;
       }
+
+      return applyHeaders(request, {
+        HttpHeaders.authorizationHeader: '$bearerPrefix $newAccessToken',
+        retryCountHeader: '1',
+      });
     }
 
     return null;
-  }
-
-  Future<String?> _refreshToken() async {
-    if (!await _authRepository.refreshToken()) {
-      throw Exception('Failed to refresh token');
-    }
-    return _authRepository.getAccessToken();
   }
 
   @override


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix a race condition with access token refresh by moving the completer up to the `AuthRepository` instead of only a local deduping in `AccessTokenAuthenticator`.
The race condition is caused e.g. by a 401 on any API request together with a simultaneous `AuthBloc.CheckTokenRequested` which triggers two parallel _appAuth.token() calls.
The second refreshed access token is then silently discarded, such that subsequent requests fails and the user is silently logged out.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Move the completer to `auth_repository` to dedupe simultaneous refreshes
- Directly return the access token in `refreshAccessToken`
- Small renaming

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Trigger two access token refreshes.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---