### PR TITLE
221: Same height for profile cards

### DIFF
--- a/lib/features/profiles/widgets/profile_card.dart
+++ b/lib/features/profiles/widgets/profile_card.dart
@@ -49,8 +49,7 @@ class ProfileCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(profile.fullName, maxLines: 1, overflow: TextOverflow.ellipsis),
-                    if (role != null)
-                      Text(role, style: theme.textTheme.labelSmall, maxLines: 1, overflow: TextOverflow.ellipsis),
+                    Text(role ?? '', style: theme.textTheme.labelSmall, maxLines: 1, overflow: TextOverflow.ellipsis),
                   ],
                 ),
               ),


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Use same height for profile cards to keep consistent layout.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Render an empty string as fallback for a role to keep the layout consistent

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See the contact cards with one member without roles.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---