### PR TITLE
1121: integrate new push notification types for challenges

### DIFF
--- a/lib/app/services/converters/remote_message_extension.dart
+++ b/lib/app/services/converters/remote_message_extension.dart
@@ -18,25 +18,33 @@ extension NullableRemoteMessageExtension on RemoteMessage? {
         return NotificationMessageType.routeAssignmentUpdate;
       case NotificationConstants.notificationTypeAreaAssignmentUpdated:
         return NotificationMessageType.areaAssignmentUpdate;
+      case NotificationConstants.notificationTypeChallengeMembershipTimeElapsed:
+        return NotificationMessageType.challengeMembershipTimeElapsed;
+      case NotificationConstants.notificationTypeChallengeMembershipTargetReached:
+        return NotificationMessageType.challengeMembershipTargetReached;
     }
+    logger.d('No push notification handler found for type `$type`');
     return null;
   }
 }
 
 extension RemoteMessageExtension on RemoteMessage {
-  BaseNotificationHandler getNotificationHandler() {
-    final type = getMessageType();
-    return GetIt.I<BaseNotificationHandler>(instanceName: type?.toString() ?? '');
+  BaseNotificationHandler? getNotificationHandler() {
+    final messageType = getMessageType();
+    if (messageType == null) {
+      return null;
+    }
+    return GetIt.I<BaseNotificationHandler>(instanceName: messageType.toString());
   }
 
   void processMessage(BuildContext? currentContext) {
     var handler = getNotificationHandler();
-    handler.processMessage(this, currentContext);
+    handler?.processMessage(this, currentContext);
   }
 
   String? getPayload() {
     var handler = getNotificationHandler();
-    return handler.getPayload(this);
+    return handler?.getPayload(this);
   }
 }
 
@@ -44,11 +52,15 @@ extension NotificationResponseExtension on NotificationResponse {
   BaseNotificationHandler? getNotificationHandler() {
     var localPayload = payload;
     NotificationMessageType? instanceIdentifier;
-    if (localPayload == null) throw UnimplementedError();
+    if (localPayload == null || localPayload.trim().isEmpty) throw UnimplementedError();
     if (localPayload.startsWith(NotificationConstants.payloadNewsPrefix)) {
       instanceIdentifier = NotificationMessageType.news;
     } else if (localPayload.startsWith(NotificationConstants.payloadMfa)) {
       instanceIdentifier = NotificationMessageType.mfa;
+    } else if (localPayload.startsWith(NotificationConstants.payloadCampaignsChallengeMembershipTimeElapsedPrefix)) {
+      instanceIdentifier = NotificationMessageType.challengeMembershipTimeElapsed;
+    } else if (localPayload.startsWith(NotificationConstants.payloadCampaignsChallengeMembershipTargetReachedPrefix)) {
+      instanceIdentifier = NotificationMessageType.challengeMembershipTargetReached;
     } else if (localPayload == NotificationConstants.payloadTeam) {
       instanceIdentifier = NotificationMessageType.teamMembershipUpdate;
     } else if (localPayload == NotificationConstants.payloadTeamTop10) {

--- a/lib/app/services/notification_message_type.dart
+++ b/lib/app/services/notification_message_type.dart
@@ -5,4 +5,6 @@ enum NotificationMessageType {
   routeAssignmentUpdate,
   areaAssignmentUpdate,
   teamTop10Update,
+  challengeMembershipTimeElapsed,
+  challengeMembershipTargetReached,
 }

--- a/lib/app/services/push_notification_handlers/challenge_membership_target_reached_handler.dart
+++ b/lib/app/services/push_notification_handlers/challenge_membership_target_reached_handler.dart
@@ -1,0 +1,32 @@
+part of 'notification_handlers.dart';
+
+class ChallengeMembershipTargetReachedHandler extends BaseNotificationHandler {
+  @override
+  void processMessage(RemoteMessage message, BuildContext? context) {
+    final challengeId = _getChallengeId(message);
+    if (context == null || challengeId == null) return;
+    ChallengeHelper.openChallenge(context, challengeId);
+  }
+
+  @override
+  String? getPayload(RemoteMessage message) {
+    final challengeId = _getChallengeId(message);
+    return challengeId != null
+        ? '${NotificationConstants.payloadCampaignsChallengeMembershipTargetReachedPrefix}$challengeId'
+        : null;
+  }
+
+  @override
+  void processPayload(NotificationResponse response, BuildContext? context) {
+    final challengeId = response.payload?.replaceFirst(
+      NotificationConstants.payloadCampaignsChallengeMembershipTargetReachedPrefix,
+      '',
+    );
+    if (context == null || challengeId == null) return;
+    ChallengeHelper.openChallenge(context, challengeId);
+  }
+
+  String? _getChallengeId(RemoteMessage message) {
+    return message.data['challengeId']?.toString();
+  }
+}

--- a/lib/app/services/push_notification_handlers/challenge_membership_time_elapsed_handler.dart
+++ b/lib/app/services/push_notification_handlers/challenge_membership_time_elapsed_handler.dart
@@ -1,0 +1,32 @@
+part of 'notification_handlers.dart';
+
+class ChallengeMembershipTimeElapsedHandler extends BaseNotificationHandler {
+  @override
+  void processMessage(RemoteMessage message, BuildContext? context) {
+    final challengeId = _getChallengeId(message);
+    if (context == null || challengeId == null) return;
+    ChallengeHelper.openChallenge(context, challengeId);
+  }
+
+  @override
+  String? getPayload(RemoteMessage message) {
+    final challengeId = _getChallengeId(message);
+    return challengeId != null
+        ? '${NotificationConstants.payloadCampaignsChallengeMembershipTimeElapsedPrefix}$challengeId'
+        : null;
+  }
+
+  @override
+  void processPayload(NotificationResponse response, BuildContext? context) {
+    final challengeId = response.payload?.replaceFirst(
+      NotificationConstants.payloadCampaignsChallengeMembershipTimeElapsedPrefix,
+      '',
+    );
+    if (context == null || challengeId == null) return;
+    ChallengeHelper.openChallenge(context, challengeId);
+  }
+
+  String? _getChallengeId(RemoteMessage message) {
+    return message.data['challengeId']?.toString();
+  }
+}

--- a/lib/app/services/push_notification_handlers/notification_constants.dart
+++ b/lib/app/services/push_notification_handlers/notification_constants.dart
@@ -5,6 +5,9 @@ class NotificationConstants {
   static const String payloadTeam = 'team';
   static const String payloadNewsPrefix = 'news.';
   static const String payloadMfa = 'mfa';
+  static const String payloadCampaignsChallengeMembershipTimeElapsedPrefix = 'campaignsChallengeMembershipTimeElapsed.';
+  static const String payloadCampaignsChallengeMembershipTargetReachedPrefix =
+      'campaignsChallengeMembershipTargetReached.';
 
   static const notificationTypeNews = 'news.published';
   static const notificationTypeMfa = 'mfa';
@@ -12,4 +15,6 @@ class NotificationConstants {
   static const notificationTypeTeamTop10Updated = 'campaigns.team-top10.updated';
   static const notificationTypeRouteAssignmentUpdated = 'campaigns.routeAssignment.updated';
   static const notificationTypeAreaAssignmentUpdated = 'campaigns.areaAssignment.updated';
+  static const notificationTypeChallengeMembershipTimeElapsed = 'campaigns.challengeMembership.time.elapsed';
+  static const notificationTypeChallengeMembershipTargetReached = 'campaigns.challengeMembership.target.reached';
 }

--- a/lib/app/services/push_notification_handlers/notification_handlers.dart
+++ b/lib/app/services/push_notification_handlers/notification_handlers.dart
@@ -7,10 +7,13 @@ import 'package:go_router/go_router.dart';
 import 'package:gruene_app/app/auth/bloc/auth_bloc.dart';
 import 'package:gruene_app/app/constants/route_locations.dart';
 import 'package:gruene_app/features/campaigns/controllers/team_refresh_controller.dart';
+import 'package:gruene_app/features/campaigns/helper/challenge_helper.dart';
 
 part 'base_notification_handler.dart';
 part 'news_notification_handler.dart';
 part 'mfa_notification_handler.dart';
 part 'team_notification_handler.dart';
 part 'team_top10_notification_handler.dart';
+part 'challenge_membership_time_elapsed_handler.dart';
+part 'challenge_membership_target_reached_handler.dart';
 part 'notification_constants.dart';

--- a/lib/app/services/push_notification_service.dart
+++ b/lib/app/services/push_notification_service.dart
@@ -106,7 +106,7 @@ class PushNotificationService {
     if (fbToken != null) {
       // register device on api for api controlled events
       var userService = GetIt.I<GrueneApiUserService>();
-      userService.addDeviceToken(fbToken);
+      await userService.addDeviceToken(fbToken);
     }
 
     final newTopics = await _getFcmTopics();

--- a/lib/features/campaigns/helper/challenge_helper.dart
+++ b/lib/features/campaigns/helper/challenge_helper.dart
@@ -76,11 +76,15 @@ class ChallengeHelper {
     showToastAsSnack(context, t.campaigns.challenges.leaveConfirmationDialog.leaveToast(title: challenge.title));
   }
 
-  static void openChallenge(BuildContext context, Challenge challenge) {
-    context.push(RouteLocations.getRoute([RouteLocations.campaignChallengesDetail, challenge.id]), extra: challenge);
+  static void openChallenge(BuildContext context, String challengeId, {Object? extra}) {
+    context.push(RouteLocations.getRoute([RouteLocations.campaignChallengesDetail, challengeId]), extra: extra);
   }
 
-  static void openJoinedChallenge(BuildContext context, JoinedChallenge challenge) {
-    context.push(RouteLocations.getRoute([RouteLocations.campaignChallengesDetail, challenge.id]), extra: challenge);
+  static void openChallengeAsChallenge(BuildContext context, Challenge challenge) {
+    openChallenge(context, challenge.id, extra: challenge);
+  }
+
+  static void openChallengeAsJoined(BuildContext context, JoinedChallenge challenge) {
+    openChallenge(context, challenge.id, extra: challenge);
   }
 }

--- a/lib/features/campaigns/screens/challenge_badge_statistics_detail.dart
+++ b/lib/features/campaigns/screens/challenge_badge_statistics_detail.dart
@@ -41,7 +41,7 @@ class ChallengeBadgeStatisticsDetail extends StatelessWidget {
 
   Widget getBadgeIcon(BuildContext context, JoinedChallenge challenge) {
     return InkWell(
-      onTap: () => ChallengeHelper.openJoinedChallenge(context, challenge),
+      onTap: () => ChallengeHelper.openChallengeAsJoined(context, challenge),
       child: ChallengeBadge(
         activityType: challenge.activities.firstOrNull?.type ?? ChallengeActivityType.house,
         variant: .dark,

--- a/lib/features/campaigns/screens/challenges/my_challenges_widget.dart
+++ b/lib/features/campaigns/screens/challenges/my_challenges_widget.dart
@@ -53,7 +53,7 @@ class MyChallengesWidget extends StatelessWidget {
     var progressInfo = challenge.getProgressInfo();
     return Card(
       child: InkWell(
-        onTap: () => ChallengeHelper.openJoinedChallenge(context, challenge),
+        onTap: () => ChallengeHelper.openChallengeAsJoined(context, challenge),
         child: SizedBox(
           height: 250,
           width: 200,

--- a/lib/features/campaigns/screens/challenges_screen.dart
+++ b/lib/features/campaigns/screens/challenges_screen.dart
@@ -228,7 +228,7 @@ class _ChallengesScreenState extends State<ChallengesScreen> {
       padding: const EdgeInsets.symmetric(horizontal: 8),
       child: Card(
         child: InkWell(
-          onTap: () => ChallengeHelper.openChallenge(context, challenge),
+          onTap: () => ChallengeHelper.openChallengeAsChallenge(context, challenge),
           child: SizedBox(
             height: 150,
             child: Row(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -98,6 +98,22 @@ Future<void> main() async {
   GetIt.I.registerSingleton<OpenInvitationCampaignValueStore>(OpenInvitationCampaignValueStore());
   GetIt.I.registerSingleton<ActiveCampaignNotifier>(ActiveCampaignNotifier());
   GetIt.I.registerSingleton<NewCampaignNotifier>(NewCampaignNotifier());
+  initializeTimers();
+  GetIt.I.registerSingleton<FileManager>(FileManager());
+  GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.poster.toString());
+  GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.flyer.toString());
+  GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.door.toString());
+  GetIt.I.registerSingleton<TeamRefreshController>(TeamRefreshController());
+  initializeApiServices();
+  intializeNotficationHandlers();
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // setupCachePeriodicFlushing();
+
+  runApp(TranslationProvider(child: MyApp(navigatorKey: navigatorKey)));
+}
+
+void initializeTimers() {
   GetIt.I.registerSingleton<BackgroundTimer>(
     AppTimers.getCampaignActionCacheTimer(),
     instanceName: 'campaignActionCacheTimer',
@@ -111,11 +127,9 @@ Future<void> main() async {
     AppTimers.getCheckForNewCampaignsTimer(),
     instanceName: 'checkForNewCampaignsTimer',
   );
-  GetIt.I.registerSingleton<FileManager>(FileManager());
-  GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.poster.toString());
-  GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.flyer.toString());
-  GetIt.I.registerSingleton<MapScreenController>(MapScreenController(), instanceName: PoiServiceType.door.toString());
-  GetIt.I.registerSingleton<TeamRefreshController>(TeamRefreshController());
+}
+
+void initializeApiServices() {
   GetIt.I.registerFactory<GrueneApiPosterService>(() => GrueneApiPosterService());
   GetIt.I.registerFactory<GrueneApiDoorService>(() => GrueneApiDoorService());
   GetIt.I.registerFactory<GrueneApiFlyerService>(() => GrueneApiFlyerService());
@@ -129,7 +143,9 @@ Future<void> main() async {
   GetIt.I.registerFactory<GrueneApiProfileService>(() => GrueneApiProfileService());
   GetIt.I.registerFactory<GrueneApiUserService>(() => GrueneApiUserService());
   GetIt.I.registerFactory<GrueneApiChallengeService>(() => GrueneApiChallengeService());
+}
 
+void intializeNotficationHandlers() {
   GetIt.I.registerFactory<BaseNotificationHandler>(
     () => NewsNotificationHandler(),
     instanceName: NotificationMessageType.news.toString(),
@@ -154,11 +170,14 @@ Future<void> main() async {
     () => TeamTop10NotificationHandler(),
     instanceName: NotificationMessageType.teamTop10Update.toString(),
   );
-  WidgetsFlutterBinding.ensureInitialized();
-
-  // setupCachePeriodicFlushing();
-
-  runApp(TranslationProvider(child: MyApp(navigatorKey: navigatorKey)));
+  GetIt.I.registerFactory<BaseNotificationHandler>(
+    () => ChallengeMembershipTimeElapsedHandler(),
+    instanceName: NotificationMessageType.challengeMembershipTimeElapsed.toString(),
+  );
+  GetIt.I.registerFactory<BaseNotificationHandler>(
+    () => ChallengeMembershipTargetReachedHandler(),
+    instanceName: NotificationMessageType.challengeMembershipTargetReached.toString(),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -108,8 +108,6 @@ Future<void> main() async {
   intializeNotficationHandlers();
   WidgetsFlutterBinding.ensureInitialized();
 
-  // setupCachePeriodicFlushing();
-
   runApp(TranslationProvider(child: MyApp(navigatorKey: navigatorKey)));
 }
 


### PR DESCRIPTION
### Short Description

We can now show push notifications for the time elapsed events and target reached events for challenges

All open the challenge screen upon activation the message in the drawer.

<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1121

---