### PR TITLE
Quote challenge title within join/leave snackbar

### DIFF
--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -338,11 +338,11 @@
         "dialogTitle": "Challenge-Funktion nutzen",
         "dialogText": "Bitte beachte, dass du als Challenge-Teilnehmer*in namentlich in der Rangliste aufgeführt werden kannst. Deine Sichtbarkeits-Einstellungen greifen hier nicht.",
         "dialogAccept": "Teilnehmen",
-        "joinToast": "Challenge ${title} beigetreten. Viel Erfolg!"
+        "joinToast": "Challenge \"${title}\" beigetreten. Viel Erfolg!"
       },
       "leaveConfirmationDialog": {
         "dialogText": "Diese Challenge wirklich verlassen?",
-        "leaveToast": "Challenge ${title} verlassen."
+        "leaveToast": "Challenge \"${title}\" verlassen."
       },
       "actions": {
         "join": "Beitreten",


### PR DESCRIPTION
### Short Description

Wrap the ${title} placeholder in double quotes in the German i18n file (lib/i18n/de.json) for join and leave to improve readability and consistency with push notifications (see [617](https://github.com/verdigado/gruene-api/pull/617)).

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---