### PR TITLE
Add release-notes skill

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: release-notes
+description: Write the German app store release notes for the current version and print them in the chat.
+disable-model-invocation: true
+---
+
+# Release Notes
+
+Schreib die Release Notes für die aktuelle Version. Ausgabe nur hier im Chat —
+nichts committen, keine Datei anlegen.
+
+## 1. Letzte veröffentlichte Version + Notes holen
+
+```bash
+curl -s "https://itunes.apple.com/lookup?bundleId=de.gruene.wkapp&country=de" \
+  | jq -r '.results[0] | .version, "---", .releaseNotes'
+```
+
+`version` ist die letzte im App Store veröffentlichte Version und entspricht
+einem Git-Tag. `releaseNotes` sind die Notes dieser Version.
+
+## 2. Änderungen sammeln
+
+```bash
+git fetch --tags
+git log --oneline <version>..HEAD
+```
+
+Nur aufnehmen, was Nutzer:innen tatsächlich merken. Weglassen: interne
+Refactorings, CI, Dependabot, Version-Bumps, Test-Änderungen.
+
+Die History mischt Squash-Merges (Titel beschreibt die Änderung) mit
+Merge-Commits (Titel enthält nur den Branch-Namen). Wo der Titel nichts sagt,
+schau in die enthaltenen Commits oder in den verlinkten Issue.
+
+## 3. Format übernehmen
+
+Format, Sprache und Tonfall aus den in Schritt 1 geholten Store-Notes
+übernehmen — gleiche Struktur, gleiche Anrede, gleiche Art von Aufzählung.
+
+## 4. Text schreiben
+
+Ein Text für beide Stores, max. 500 Zeichen (Play-Limit; Apple erlaubt 4000).
+
+- Klartext, kein Markdown, kein HTML
+- keine spitzen Klammern
+- keine Emojis
+- kein ALL CAPS
+- keine Werbung, keine Handlungsaufforderungen
+
+Am Ende die Zeichenzahl mit ausgeben.


### PR DESCRIPTION
### Short Description

Adds a Claude Code skill that writes the German app store release notes for the current version, invoked manually as `/release-notes`.

### Proposed Changes

- Pulls the last published version and its notes from the iTunes lookup API, so the new text copies the format and tone that is already live in the store.
- Collects user-visible changes from the commit range between that version's tag and HEAD, and names what to leave out (refactorings, CI, Dependabot, version bumps).
- Enforces the store constraints in one place: 500 characters (Play limit), plain text only, no emoji, no all caps, no calls to action.

Output goes to the chat only — the skill never writes files or commits. `disable-model-invocation: true` keeps it out of automatic skill matching, so it runs only when someone types the slash command.

### Testing

Run `/release-notes` on a branch that is ahead of the latest store release and check that the generated text matches the shape of the current store notes and stays under 500 characters.

### Example output

*2026.7.0 (385 Zeichen)*

```
Neu: Mehr Infos im Profil!
- Alle Gliederungen, in denen du Mitglied bist, mit allen deinen Rollen
- Profilkarten und Suche in der eigenen Gliederung
- Mitglieder direkt per E-Mail kontaktieren

Weitere Verbesserungen:
- Filter zeigen ausgewählte Optionen zuerst und mit Haken
- Einzelne Filterauswahl lässt sich wieder aufheben
- Zuverlässigere Rückmeldung beim Ändern des Profilbilds
```

*2026.7.1 (361 Zeichen)*

```
Neu: Challenges!
- Challenges entdecken, beitreten und jederzeit wieder verlassen
- Fortschritt und Bestenliste in der Detailansicht jeder Challenge
- Abzeichen für abgeschlossene Challenges in deinen Statistiken
- Push-Nachrichten halten dich zu deinen Challenges auf dem Laufenden

Weitere Verbesserungen:
- Stabilere Anmeldung, seltener unerwartetes Abmelden
```
